### PR TITLE
[ch14453] added link around logo to redirect to helphub apis

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -56,9 +56,11 @@ under the License.
                 Menu
         </button>
         
-        <img class="ods-header__logo"
-              src="<%= image_path('ODS_logo_api_blanc.svg') %>"
-              alt="OpenDataSoft API documentation">
+        <a href="/en/apis/">
+          <img class="ods-header__logo"
+                src="<%= image_path('ODS_logo_api_blanc.svg') %>"
+                alt="OpenDataSoft API documentation">
+        </a>
 
         <button type="button"
                 class="ods-header__menu-toggle"


### PR DESCRIPTION
### Description

All links to navigate or return to the home page are present in the header, however it is a natural behavior to click on the logo to return to the home page.

**Story Clubhouse :**
https://app.clubhouse.io/opendatasoft/story/14453/brand-logo-doesn-t-link-to-the-homepage