### PR TITLE
Feature/new items nav

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -79,7 +79,7 @@ under the License.
         <div class="ods-header__nav-item">
           <a class="ods-header__nav-item-link"
               href="/platform/en/">
-              Platform
+              User guide
           </a>
         </div>
         <div class="ods-header__nav-item">
@@ -104,6 +104,12 @@ under the License.
           <a class="ods-header__nav-item-link ods-header__nav-item-link--active"
               href="/en/apis/">
               APIs
+          </a>
+        </div>
+        <div class="ods-header__nav-item">
+          <a class="ods-header__nav-item-link"
+              href="/tutorials/en/">
+              Tutorials
           </a>
         </div>
       </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -56,9 +56,11 @@ under the License.
                 Menu
         </button>
         
-        <img class="ods-header__logo"
-              src="<%= image_path('ODS_logo_api_blanc.svg') %>"
-              alt="OpenDataSoft API documentation">
+        <a href="/en/apis/">
+          <img class="ods-header__logo"
+                src="<%= image_path('ODS_logo_api_blanc.svg') %>"
+                alt="OpenDataSoft API documentation">
+        </a>
 
         <button type="button"
                 class="ods-header__menu-toggle"


### PR DESCRIPTION
### Description : 

With the arrival of the new "Tutorial" section in the HelpHub, I added the Tutorials link in the navigation bar and the "Platform" element has been revised to "User Guide".

#### Other : 

In addition, all links to navigate or return to the home page are present in the header, however it is a natural behavior to click on the logo to return to the home page.

Story Clubhouse :
https://app.clubhouse.io/opendatasoft/story/14453/brand-logo-doesn-t-link-to-the-homepage