### PR TITLE
Remove mention of basic auth support

### DIFF
--- a/source/includes/common/authentication.md
+++ b/source/includes/common/authentication.md
@@ -5,7 +5,6 @@ An authenticated user can be granted access to restricted datasets and benefit f
 For the platform to authenticate a user, you need to either:
 
 * be logged in a portal so a session cookie authenticating your user is passed along your API calls
-* provide your username and password as HTTP Basic authentication tokens
 * provide an **API key** as a request parameter
 
 ## Finding and generating API keys

--- a/source/includes/v1/available_apis.md
+++ b/source/includes/v1/available_apis.md
@@ -52,7 +52,6 @@ All API endpoints are available in HTTPS, which use is highly recommended wherev
 
 The following authentication modes are available:
 
-- **HTTP Basic authentication:** via an account login and password ([https://en.wikipedia.org/wiki/Basic_access_authentication](https://en.wikipedia.org/wiki/Basic_access_authentication))
 - **API key authentication:** via an API key generated from [the account settings page](https://docs.opendatasoft.com/en/using_api/authentication.html#finding-and-generating-api-keys)
 - **Session authentication:** API calls performed from a browser will authenticate logged users via the Opendatasoft session cookie
 


### PR DESCRIPTION
it's only half working and will not be supported in the long term so we should avoid having people use that.

https://app.clubhouse.io/opendatasoft/story/14739/remove-basic-auth-mentions-from-oauth2-api-documentation