### PR TITLE
Update the examples in the WFS API docs

### DIFF
--- a/source/includes/wfs/describe_feature_type.md
+++ b/source/includes/wfs/describe_feature_type.md
@@ -3,13 +3,13 @@
 > `DescribeFeatureType` operation with the optional `TypeName` parameter
 
 ```http
-GET https://examples.opendatasoft.com/api/wfs?service=WFS&request=DescribeFeatureType&typeName=ods:world-heritage-unesco-list HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/wfs?service=WFS&request=DescribeFeatureType&typeName=ods:roman-emperors HTTP/1.1
 ```
 
 > Same request using a POST method
 
 ```http
-POST https://examples.opendatasoft.com/api/wfs HTTP/1.1
+POST documentation-resources.opendatasoft/api/wfs HTTP/1.1
 ```
 
 ```xml
@@ -20,7 +20,7 @@ POST https://examples.opendatasoft.com/api/wfs HTTP/1.1
     xmlns="http://www.opengis.net/wfs"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.opengis.net/wfs ../wfs/1.1.0/WFS.xsd">
-    <TypeName>ods:world-heritage-unesco-list</TypeName>
+    <TypeName>ods:roman-emperors</TypeName>
 </DescribeFeatureType>
 ```
 

--- a/source/includes/wfs/describe_feature_type.md
+++ b/source/includes/wfs/describe_feature_type.md
@@ -31,8 +31,8 @@ The `DescribeFeatureType` operation generates a schema description of features t
 This is the list of the supported parameters specific to the `DescribeFeatureType` operation. You should also take into
 consideration the common parameters. [See more](#parameters)
 
-The existing parameters in the WFS standard which are not listed in this table are currently not supported.
+The existing parameters in the WFS standard that are not listed in this table are currently not supported.
 
 Parameter | Description | Optionality and use
 --------- | ----------- | -------------------
-`TypeName` | A comma separated list of feature types to describe. If no value is specified that is to be interpreted as all <br> feature types. | Optional. When omitted, return all types known.
+`TypeName` | A comma-separated list of feature types to describe. | Optional. When omitted, return all feature types known.

--- a/source/includes/wfs/get_capabilities.md
+++ b/source/includes/wfs/get_capabilities.md
@@ -37,12 +37,12 @@ containing the information.
 This is the list of the supported parameters specific to the `GetCapabilities` operation. You should also take into
 consideration the common parameters. [See more](#parameters).
 
-The existing parameters in the WFS standard which are not listed in this table are currently not supported.
+The existing parameters in the WFS standard that are not listed in this table are currently not supported.
 
 Parameter | Description | Optionality and use
 --------- | ----------- | -------------------
-`Sections` | Unordered list of zero or more names of sections of service metadata document to be returned in service metadata <br> document. | Optional. When omitted, return complete service metadata document.
-`AcceptVersions` | Prioritized sequence of one or more specification versions accepted by client, with preferred versions listed <br> first. | Optional. When omitted, return latest supported version.
+`Sections` | Unordered list of zero or more names of sections of service metadata document to be returned in service metadata <br> document. | Optional. When omitted, returns the complete service metadata document.
+`AcceptVersions` | Prioritized sequence of one or more specification versions accepted by client, with preferred versions listed <br> first. | Optional. When omitted, returns the latest supported version.
 
 ### Sections
 
@@ -53,5 +53,5 @@ Section name | Content
 ------------ | -------
 `ServiceIdentification` | Metadata about the WFS implementation
 `ServiceProvider` | Metadata about the organization offering the WFS service
-`OperationsMetadata` | Metadata about the WFS operations offered by a the WFS implementation
-`FeatureTypeList` | This section defines the list of features types that are available from the service
+`OperationsMetadata` | Metadata about the WFS operations offered by the WFS implementation
+`FeatureTypeList` | List of features types that are available from the service

--- a/source/includes/wfs/get_capabilities.md
+++ b/source/includes/wfs/get_capabilities.md
@@ -5,13 +5,13 @@
 > `GetCapabilities` operation with the optional `Sections` parameter
 
 ```http
-GET https://examples.opendatasoft.com/api/wfs?service=WFS&request=GetCapabilities&sections=OperationsMetadata,FeatureTypeList HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/wfs?service=WFS&request=GetCapabilities&sections=OperationsMetadata,FeatureTypeList HTTP/1.1
 ```
 
 > Same request using a POST method
 
 ```http
-POST https://examples.opendatasoft.com/api/wfs HTTP/1.1
+POST https://documentation-resources.opendatasoft.com/api/wfs HTTP/1.1
 ```
 
 ```xml

--- a/source/includes/wfs/get_feature.md
+++ b/source/includes/wfs/get_feature.md
@@ -3,13 +3,13 @@
 > `GetFeature` operation with the optional `PropertyName` parameter
 
 ```http
-GET https://examples.opendatasoft.com/api/wfs?service=WFS&request=GetFeature&typename=ods:world-heritage-unesco-list&propertyname=ods:world-heritage-unesco-list/geo_shape HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/wfs?service=WFS&request=GetFeature&typename=ods:roman-emperors&propertyname=ods:roman-emperors/name HTTP/1.1
 ```
 
 > Same request using a POST method
 
 ```http
-POST https://examples.opendatasoft.com/api/wfs HTTP/1.1
+POST https://documentation-resources.opendatasoft.com/api/wfs HTTP/1.1
 ```
 
 ```xml
@@ -22,8 +22,8 @@ POST https://examples.opendatasoft.com/api/wfs HTTP/1.1
   xmlns:myns="http://www.someserver.com/myns"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opengis.net/wfs ../wfs/1.1.0/WFS.xsd">
-  <wfs:Query typeName="ods:world-heritage-unesco-list">
-      <wfs:PropertyName>geo_shape</wfs:PropertyName>
+  <wfs:Query typeName="ods:roman-emperors">
+      <wfs:PropertyName>name</wfs:PropertyName>
   </wfs:Query>
 </wfs:GetFeature>
 ```

--- a/source/includes/wfs/get_feature.md
+++ b/source/includes/wfs/get_feature.md
@@ -36,11 +36,11 @@ representation.
 This is the list of the supported parameters specific to the `GetFeature` operation. You should also take into
 consideration the common parameters. [See more](#parameters).
 
-The existing parameters in the WFS standard which are not listed in this table are currently not supported.
+The existing parameters in the WFS standard that are not listed in this table are currently not supported.
 
 Parameter | Description | Optionality and use
 --------- | ----------- | -------------------
-`resultType` | Used to indicate whether a WFS should generate a complete response document of whether it should generate an <br> empty response document indicating only the number of features that the query would return | Optional. Values can be `hits` or `results`. Default value is `results`
+`resultType` | Used to indicate whether a WFS should generate a complete response document or an <br> empty response document indicating only the number of features that the query would return | Optional. Values can be `hits` or `results`. Default value is `results`
 `maxFeatures` | Used to define the maximum number of records that should be returned from the result set of a query | Optional. Value must be a positive integer
 `TypeName` | A list of feature type names to query | Mandatory
 `PropertyName` | A list of properties that should be returned | Optional. The absence of a value also indicates that all properties should be fetched

--- a/source/includes/wfs/introduction.md
+++ b/source/includes/wfs/introduction.md
@@ -20,12 +20,12 @@ Operation | Description
 > Service entry address
 
 ```http
-GET https://examples.opendatasoft.com/api/wfs HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/wfs HTTP/1.1
 ```
 
 The service can be reached at the following entry address.
 
-For this documentation, we use the domain `https://examples.opendatasoft.com` as an example but you should replace it
+For this documentation, we use the domain `https://documentation-resources.opendatasoft.com/` as an example but you should replace it
 by your custom domain name.
 
 The WFS supports both `GET` and `POST` HTTP methods.

--- a/source/includes/wfs/introduction.md
+++ b/source/includes/wfs/introduction.md
@@ -25,8 +25,7 @@ GET https://documentation-resources.opendatasoft.com/api/wfs HTTP/1.1
 
 The service can be reached at the following entry address.
 
-For this documentation, we use the domain `https://documentation-resources.opendatasoft.com/` as an example but you should replace it
-by your custom domain name.
+The domain `https://documentation-resources.opendatasoft.com/` is used as an example in this documentation, but you should replace it with your custom domain name.
 
 The WFS supports both `GET` and `POST` HTTP methods.
 


### PR DESCRIPTION
## Summary

This PR consolidates all examples based on examples, public, or other domains to examples based on the documentation-resources domain.

Story details: https://app.clubhouse.io/opendatasoft/story/26016

## Changes

- Updated examples in WFS API docs with paths and datasets from `documentation-resources`. The UNESCO dataset could not be used anymore, [roman-emperors](https://documentation-resources.opendatasoft.com/explore/dataset/roman-emperors/table/) is now used to show request and response examples.
- Fixed typos and grammar issues.