### PR TITLE
Update the examples in the CSW API docs

### DIFF
--- a/source/includes/csw/describe_record.md
+++ b/source/includes/csw/describe_record.md
@@ -4,13 +4,13 @@
 > `DescribeRecord` operation with the optional `TypeName` parameter
 
 ```http
-GET https://examples.opendatasoft.com/api/csw?service=CSW&request=DescribeRecord&typename=csw:Record HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/csw?service=CSW&request=DescribeRecord&typename=csw:Record HTTP/1.1
 ```
 
 > Same request using a POST method
 
 ```http
-POST https://examples.opendatasoft.com/api/csw HTTP/1.1
+POST https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
 ```
 
 ```xml

--- a/source/includes/csw/describe_record.md
+++ b/source/includes/csw/describe_record.md
@@ -29,15 +29,15 @@ POST https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
 ```
 
 The `DescribeRecord` operation allows clients to discover elements of the information model supported by the
-catalogue service.
+catalog service.
 
 ### Parameters
 
 This is the list of the supported parameters specific to the `DescribeRecord` operation. You should also take into
-consideration the common parameters. [See more](parameters).
+consideration the common [parameters](#parameters).
 
 The existing parameters in the CSW standard which are not listed in this table are currently not supported.
 
 Parameter | Description | Optionality and use
 --------- | ----------- | -------------------
-`TypeName` | Unordered list of zero or more type names that are to be described by the catalogue. | Optional. When omitted, return all types known.
+`TypeName` | Unordered list of zero or more type names that are to be described by the catalog. | Optional. When omitted, return all types known.

--- a/source/includes/csw/get_capabilities.md
+++ b/source/includes/csw/get_capabilities.md
@@ -11,7 +11,7 @@ GET https://documentation-resources.opendatasoft.com/api/csw?service=CSW&request
 > Example POST request
 
 ```http
-POST hhttps://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
+POST https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
 ```
 
 ```xml

--- a/source/includes/csw/get_capabilities.md
+++ b/source/includes/csw/get_capabilities.md
@@ -35,14 +35,14 @@ containing the information.
 ### Parameters
 
 This is the list of the supported parameters specific to the `GetCapabilities` operation. You should also take into
-consideration the common parameters. [See more](#parameters).
+consideration the common [parameters](#parameters).
 
-The existing parameters in the CSW standard which are not listed in this table are currently not supported.
+The existing parameters in the CSW standard that are not listed in this table are currently not supported.
 
 Parameter | Description | Optionality and use
 --------- | ----------- | -------------------
-`Sections` |	Unordered list of zero or more names of sections of service metadata document to be returned in service metadata document. | Optional. When omitted, return complete service metadata document.
-`AcceptVersions` | Prioritized sequence of one or more specification versions accepted by client, with preferred versions listed first.	| Optional. When omitted, return latest supported version.
+`Sections` |	Unordered list of zero or more names of sections of service metadata document to be returned in service metadata document. | Optional. When omitted, returns the complete service metadata document.
+`AcceptVersions` | Prioritized sequence of one or more specification versions accepted by client, with preferred versions listed first.	| Optional. When omitted, returns the latest supported version.
 
 ### Sections
 

--- a/source/includes/csw/get_capabilities.md
+++ b/source/includes/csw/get_capabilities.md
@@ -5,13 +5,13 @@
 > Example GET request
 
 ```http
-GET https://examples.opendatasoft.com/api/csw?service=CSW&request=GetCapabilities&sections=ServiceIdentification,ServiceProvider HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/csw?service=CSW&request=GetCapabilities&sections=ServiceIdentification,ServiceProvider HTTP/1.1
 ```
 
 > Example POST request
 
 ```http
-POST https://examples.opendatasoft.com/api/csw HTTP/1.1
+POST hhttps://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
 ```
 
 ```xml

--- a/source/includes/csw/get_record_by_id.md
+++ b/source/includes/csw/get_record_by_id.md
@@ -26,13 +26,13 @@ POST https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
   </GetRecordById>
 ```
 
-The `GetRecordById` operation allows clients to retrieve the representation of catalogue records using their
+The `GetRecordById` operation allows clients to retrieve the representation of catalog records using their
 identifier. The response is an XML document and the output schema can be specified.
 
 ### Parameters
 
 This is the list of the supported parameters specific to the `GetRecordById` operation. You should also take into
-consideration the common parameters. [See more](#parameters).
+consideration the common [parameters](#parameters).
 
 The existing parameters in the CSW standard which are not listed in this table are currently not supported.
 

--- a/source/includes/csw/get_record_by_id.md
+++ b/source/includes/csw/get_record_by_id.md
@@ -3,13 +3,13 @@
 > `GetRecordById` operation with the optional `outputSchema` parameter
 
 ```http
-GET https://examples.opendatasoft.com/api/csw?service=CSW&request=GetRecordById&outputschema=http://www.isotc211.org/2005/gmd&id=world-heritage-unesco-list HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/csw?service=CSW&request=GetRecordById&outputschema=http://www.isotc211.org/2005/gmd&id=roman-emperors HTTP/1.1
 ```
 
 > Same request using a POST method
 
 ```http
-POST https://examples.opendatasoft.com/api/csw HTTP/1.1
+POST https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
 ```
 
 ```xml
@@ -22,7 +22,7 @@ POST https://examples.opendatasoft.com/api/csw HTTP/1.1
       xmlns="http://www.opengis.net/cat/csw/2.0.2"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2/csw/2.0.2/CSW-discovery.xsd">
-      <Id>world-heritage-unesco-list</Id>
+      <Id>roman-emperors</Id>
   </GetRecordById>
 ```
 

--- a/source/includes/csw/get_records.md
+++ b/source/includes/csw/get_records.md
@@ -4,13 +4,13 @@
 `ElementSetName` parameters
 
 ```http
-GET https://examples.opendatasoft.com/api/csw?service=CSW&request=GetRecords&resulttype=results&elementsetname=full&outputschema=http://www.isotc211.org/2005/gmd&typenames=csw:Record HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/csw?service=CSW&request=GetRecords&resulttype=results&elementsetname=full&outputschema=http://www.isotc211.org/2005/gmd&typenames=csw:Record HTTP/1.1
 ```
 
 > Same request using a POST method
 
 ```http
-POST https://examples.opendatasoft.com/api/csw HTTP/1.1
+POST https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
 ```
 
 ```xml

--- a/source/includes/csw/get_records.md
+++ b/source/includes/csw/get_records.md
@@ -27,7 +27,7 @@ POST https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
       <ElementSetName>full</ElementSetName>
   </Query>
 </GetRecords>
-````
+```
 
 The `GetRecords` operation allows clients to discover resources (datasets). The response is an XML document and
 the output schema can be specified.
@@ -35,15 +35,15 @@ the output schema can be specified.
 ### Parameters
 
 This is the list of the supported parameters specific to the `GetRecords` operation. You should also take into
-consideration the common parameters. [See more](#parameters).
+consideration the common [parameters](#parameters).
 
 The existing parameters in the CSW standard which are not listed in this table are currently not supported.
 
 Parameter | Description | Optionality and use
 --------- | ----------- | -------------------
-`resultType` | Determines whether the catalogue returns just a summary of the result set, or includes one or more records from the result set. | Optional. Values can be `hits` or `results`. Default value is `hits`.
+`resultType` | Determines whether the catalog returns just a summary of the result set or includes one or more records from the result set. | Optional. Values can be `hits` or `results`. Default value is `hits`.
 `outputSchema` | Used to indicate the schema of the output that is generated in response to a `GetRecords` request. | Optional. Values can be `http://www.opengis.net/cat/csw/2.0.2` or `http://www.isotc211.org/2005/gmd`. <br> Default value is `http://www.opengis.net/cat/csw/2.0.2`.
-`startPosition` | Used to indicate at which record position the catalogue should start generating output. | Optional. Value must be a non-zero positive integer. Default value is 1.
+`startPosition` | Used to indicate at which record position the catalog should start generating output. | Optional. Value must be a non-zero positive integer. Default value is 1.
 `maxRecords` | Used to define the maximum number of records that should be returned from the result set of a query. | Optional. Value must be a positive integer. Default value is 10.
-`ElementSetName` | Used to indicate which named set the service shall present to the client. It usually defines the level of details present in the result set. | Optional. Values can be `full`, `summary` or `brief`. Default value is `summary`.
+`ElementSetName` | Used to indicate which named set the service shall present to the client. It usually defines the level of details present in the result set. | Optional. Values can be `full`, `summary`, or `brief`. Default value is `summary`.
 `typeNames` | Used to indicate which named set the service shall present to the client. It usually defines the level of details present in the result set. | Mandatory. Values can be `csw:Record` or `gmd:MD_Metadata`.

--- a/source/includes/csw/introduction.md
+++ b/source/includes/csw/introduction.md
@@ -1,6 +1,6 @@
 # CSW API
 
-Opendatasoft datasets can be accessed through a Catalog Service for the Web (CSW) API. This is a standard for exposing a catalogue of geospatial records in XML.
+Opendatasoft datasets can be accessed through a Catalog Service for the Web (CSW) API. CSW is a standard for exposing a catalog of geospatial records in XML.
 
 The Opendatasoft platform uses the CSW specification version 2.0.2.
 
@@ -11,7 +11,7 @@ Opendatasoft platform implements four operations defined by the CSW standard:
 Operation | Description
 --------- | -----------
 `GetCapabilities` | Retrieve service metadata
-`DescribeRecord` | Discover elements of the information model by the catalogue
+`DescribeRecord` | Discover elements of the information model by the catalog
 `GetRecords` | Search for records and get their metadata and identifier
 `GetRecordById` | Search for a record with a specific identifier
 

--- a/source/includes/csw/introduction.md
+++ b/source/includes/csw/introduction.md
@@ -21,13 +21,12 @@ Operation | Description
 > Service entry address
 
 ```http
-GET https://examples.opendatasoft.com/api/csw HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/csw HTTP/1.1
 ```
 
 The service can be reached at the following entry address.
 
-For this documentation, we use the domain `https://examples.opendatasoft.com` as an example but you should replace it
-by your custom domain name.
+The domain `https://documentation-resources.opendatasoft.com/` is used as an example in this documentation, but you should replace it with your custom domain name.
 
 The CSW API supports both `GET` and `POST` HTTP methods.
 


### PR DESCRIPTION
## Summary

This PR updates all examples based on different domains to examples based on the `documentation-resources` domain.

Story details: https://app.clubhouse.io/opendatasoft/story/26016

## Changes

- Updated examples in CSW API docs with paths and datasets from `documentation-resources`. The UNESCO dataset could not be used anymore, [roman-emperors](https://documentation-resources.opendatasoft.com/explore/dataset/roman-emperors/table/) is now used to show request and response examples.
- Fixed typos and grammar issues.