### PR TITLE
Update the examples in the Search API v2 docs

### DIFF
--- a/source/includes/v2/_catalog.md
+++ b/source/includes/v2/_catalog.md
@@ -41,7 +41,7 @@ The catalog API allows to:
 - export the datasets of a chosen domain's catalog
 - lookup a dataset from a domain's catalog
 
-Each endpoint above is documented in its own section, along with its available parameters. Some of these parameters however accept field literals, which are documented right below. We recommend reading the **Field literal in catalog queries** section before diving into the catalog API.
+Each endpoint above is documented in its own section, along with its available parameters. Some of these parameters accept field literals. We recommend reading the **Field literal in catalog queries** section before diving into the catalog API.
 
 
 ##### Field literal in catalog queries
@@ -62,7 +62,7 @@ Field name | Description
 ---------- | -----------
 `datasetid` | Human readable dataset identifier
 `has_records` | Boolean field indicating if a dataset contains records
-`features` | List of dataset features. Possible values: calendar, geo, image, apiproxy, timeserie and aggregate
+`features` | List of dataset features. Possible values: `calendar`, `geo`, `image`, `apiproxy`, `timeserie`, and `aggregate`
 
 ###### Dataset metadata
 
@@ -73,7 +73,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?w
 # Since modified is a `basic` metadata, `where` expression can be simplified to `modified>2015`
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?where=modified>2020'
 
-# Get datasets that have been downloaded more than a 100 times
+# Get datasets that have been downloaded more than 100 times
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?where=explore.download_count>100'
 ```
 
@@ -122,7 +122,7 @@ Parameter | Default | Description
 `exclude` | None | Exclude a given facet value from the result set (see [exclude in Facet documentation](#exclude))
 `start` | 0 | Index of the first item to return
 `rows` | 10 | Number of items to return. Max value: 100
-`include_app_metas` | false | Explicitely request application metadata for each datasets
+`include_app_metas` | false | Explicitly request application metadata for each datasets
 `timezone` | UTC | Timezone applied on datetime fields in query and response
 
 <aside>
@@ -360,7 +360,7 @@ A dataset catalog can be exported in different formats:
 
 ### Exporting a catalog in JSON
 
-> Export datasets in json format
+> Export datasets in JSON format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/json'
@@ -371,7 +371,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/js
 
 ### Exporting a catalog in CSV
 
-> Export datasets in csv format using **,** as delimiter
+> Export datasets in CSV format using **,** as delimiter
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/csv?delimiter=,'
@@ -391,7 +391,7 @@ Parameter | Default | Description
 
 ### Exporting a catalog in XLS
 
-> Export datasets in xls format
+> Export datasets in XLS format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/xls'
@@ -404,7 +404,7 @@ Export datasets to an XLS format using [SpreadsheetML specification](https://en.
 
 ### Exporting a catalog in RSS
 
-> Export datasets in rss format
+> Export datasets in RSS format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/rss'
@@ -415,7 +415,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/rs
 
 ### Exporting a catalog in TTL
 
-> Export datasets in turle rdf format
+> Export datasets in Turtle RDF format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/ttl'
@@ -428,7 +428,7 @@ Export datasets to a Turtle RDF format using [DCAT application for data portals 
 
 ### Exporting a catalog in RDF
 
-> Export datasets in rdf-xml format
+> Export datasets in RDF/XML format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/rdf'

--- a/source/includes/v2/_catalog.md
+++ b/source/includes/v2/_catalog.md
@@ -3,7 +3,7 @@
 > List available entrypoints on a catalog
 
 ```shell
-curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog'
 ```
 
 > API Response
@@ -141,15 +141,9 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates
 
 ```json
 {
-    "links": [
-        {
-            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates",
-            "rel": "self"
-        }
-    ],
     "aggregations": [
         {
-            "count": 13
+            "count": 12
         }
     ]
 }
@@ -165,12 +159,6 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates
 
 ```json
 {
-    "links": [
-        {
-            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates",
-            "rel": "self"
-        }
-    ],
     "aggregations": [
         {
             "count(*)": 12,
@@ -216,19 +204,13 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates
 > Aggregation with an multiple group_by
 
 ```shell
-curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates/?select=features,theme,count(*)&group_by=features,theme'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates/?select=features,theme,count(*)&group_by=features,theme&limit=5'
 ```
 
 > API Response
 
 ```json
 {
-    "links": [
-        {
-            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates",
-            "rel": "self"
-        }
-    ],
     "aggregations": [
         {
             "theme": "Administration, Government, Public finances, Citizenship",
@@ -254,51 +236,6 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates
             "theme": "Product",
             "count(*)": 1,
             "features": "analyze"
-        },
-        {
-            "theme": "Spatial planning, Town planning, Buildings, Equipment, Housing",
-            "count(*)": 2,
-            "features": "analyze"
-        },
-        {
-            "theme": "Culture, Heritage",
-            "count(*)": 1,
-            "features": "geo"
-        },
-        {
-            "theme": "Environment",
-            "count(*)": 1,
-            "features": "geo"
-        },
-        {
-            "theme": "Spatial planning, Town planning, Buildings, Equipment, Housing",
-            "count(*)": 2,
-            "features": "geo"
-        },
-        {
-            "theme": "Culture, Heritage",
-            "count(*)": 2,
-            "features": "timeserie"
-        },
-        {
-            "theme": "Economy, Business, SME, Economic development, Employment",
-            "count(*)": 2,
-            "features": "timeserie"
-        },
-        {
-            "theme": "Environment",
-            "count(*)": 1,
-            "features": "timeserie"
-        },
-        {
-            "theme": "Product",
-            "count(*)": 1,
-            "features": "timeserie"
-        },
-        {
-            "theme": "Spatial planning, Town planning, Buildings, Equipment, Housing",
-            "count(*)": 1,
-            "features": "timeserie"
         }
     ]
 }

--- a/source/includes/v2/_catalog.md
+++ b/source/includes/v2/_catalog.md
@@ -3,7 +3,7 @@
 > List available entrypoints on a catalog
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/'
 ```
 
 > API Response
@@ -12,19 +12,19 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/'
 
 {
 	"links": [{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog",
 			"rel": "self"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/datasets",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets",
 			"rel": "datasets"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/exports",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/exports",
 			"rel": "exports"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates",
 			"rel": "metadata_templates"
 		}
 	]
@@ -54,7 +54,7 @@ Some parameters, such as `select`, `where` or `group_by`, accept [field literals
 
 ```shell
 # Count dataset grouped by their features
-curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates?select=count(*)&group_by=features'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates?select=count(*)&group_by=features'
 # Note: (since a dataset can have multiple features, total count is not the number of datasets in the domain)
 ```
 
@@ -69,12 +69,12 @@ Field name | Description
 >  Use metadata as field literal
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets?where=default.modified>2015'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?where=default.modified>2020'
 # Since modified is a `basic` metadata, `where` expression can be simplified to `modified>2015`
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets?where=modified>2015'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?where=modified>2020'
 
 # Get datasets that have been downloaded more than a 100 times
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets?where=explore.download_count>100'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?where=explore.download_count>100'
 ```
 
 All metadata can be used as field literal in a query parameter.
@@ -89,19 +89,19 @@ The list of metadata and their types for a domain can be obtained with the [meta
 > Get first 10 datasets
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets?rows=10'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?rows=10'
 ```
 
 > Get 10 datasets starting at the 10th result
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets?rows=10&start=10'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?rows=10&start=10'
 ```
 
 > Search datasets containing `world` in their metas
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets?where="world"'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets?where="world"'
 ```
 
 This endpoint provides a search facility in the dataset catalog.
@@ -134,16 +134,22 @@ The value of both `start` and `rows` parameters must not exceed 10000. Use the e
 > Aggregation query without group_by
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=count(*) as count'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates/?select=count(*) as count'
 ```
 
 > API Response
 
 ```json
 {
+    "links": [
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates",
+            "rel": "self"
+        }
+    ],
     "aggregations": [
         {
-            "count": 2
+            "count": 13
         }
     ]
 }
@@ -152,25 +158,31 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=count(
 > Aggregation query with a single group_by
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=features,count(*) as count&group_by=features'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates/?select=features,count(*) as count&group_by=features'
 ```
 
 > API Response
 
 ```json
 {
+    "links": [
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates",
+            "rel": "self"
+        }
+    ],
     "aggregations": [
         {
-            "count": 2,
+            "count(*)": 12,
             "features": "analyze"
         },
         {
-            "count": 2,
-            "features": "timeserie"
+            "count(*)": 4,
+            "features": "geo"
         },
         {
-            "count": 1,
-            "features": "geo"
+            "count(*)": 9,
+            "features": "timeserie"
         }
     ]
 }
@@ -180,13 +192,13 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=featur
 > Invalid aggregation with a selected field not present in group_by
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=records_count'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates/?select=records_count'
 ```
 
 > Valid aggregation with an aggregation function
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=sum(records_count)'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates/?select=sum(records_count)'
 ```
 
 > API Response
@@ -195,7 +207,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=sum(re
 {
     "aggregations": [
         {
-            "sum(records_count)": 3893
+            "sum(records_count)": 105936
         }
     ]
 }
@@ -204,43 +216,91 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=sum(re
 > Aggregation with an multiple group_by
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/aggregates/?select=features,theme,count(*)&group_by=features,theme'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates/?select=features,theme,count(*)&group_by=features,theme'
 ```
 
 > API Response
 
 ```json
 {
-	"links": [{
-		"href": "https://examples.opendatasoft.com/api/v2/catalog/aggregates",
-		"rel": "self"
-	}],
-	"aggregations": [{
-			"theme": "Administration, Government, Public finances, Citizenship",
-			"count(*)": 1,
-			"features": "analyze"
-		},
-		{
-			"theme": "Culture, Heritage",
-			"count(*)": 1,
-			"features": "analyze"
-		},
-		{
-			"theme": "Administration, Government, Public finances, Citizenship",
-			"count(*)": 1,
-			"features": "timeserie"
-		},
-		{
-			"theme": "Culture, Heritage",
-			"count(*)": 1,
-			"features": "timeserie"
-		},
-		{
-			"theme": "Culture, Heritage",
-			"count(*)": 1,
-			"features": "geo"
-		}
-	]
+    "links": [
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/aggregates",
+            "rel": "self"
+        }
+    ],
+    "aggregations": [
+        {
+            "theme": "Administration, Government, Public finances, Citizenship",
+            "count(*)": 1,
+            "features": "analyze"
+        },
+        {
+            "theme": "Culture, Heritage",
+            "count(*)": 2,
+            "features": "analyze"
+        },
+        {
+            "theme": "Economy, Business, SME, Economic development, Employment",
+            "count(*)": 2,
+            "features": "analyze"
+        },
+        {
+            "theme": "Environment",
+            "count(*)": 1,
+            "features": "analyze"
+        },
+        {
+            "theme": "Product",
+            "count(*)": 1,
+            "features": "analyze"
+        },
+        {
+            "theme": "Spatial planning, Town planning, Buildings, Equipment, Housing",
+            "count(*)": 2,
+            "features": "analyze"
+        },
+        {
+            "theme": "Culture, Heritage",
+            "count(*)": 1,
+            "features": "geo"
+        },
+        {
+            "theme": "Environment",
+            "count(*)": 1,
+            "features": "geo"
+        },
+        {
+            "theme": "Spatial planning, Town planning, Buildings, Equipment, Housing",
+            "count(*)": 2,
+            "features": "geo"
+        },
+        {
+            "theme": "Culture, Heritage",
+            "count(*)": 2,
+            "features": "timeserie"
+        },
+        {
+            "theme": "Economy, Business, SME, Economic development, Employment",
+            "count(*)": 2,
+            "features": "timeserie"
+        },
+        {
+            "theme": "Environment",
+            "count(*)": 1,
+            "features": "timeserie"
+        },
+        {
+            "theme": "Product",
+            "count(*)": 1,
+            "features": "timeserie"
+        },
+        {
+            "theme": "Spatial planning, Town planning, Buildings, Equipment, Housing",
+            "count(*)": 1,
+            "features": "timeserie"
+        }
+    ]
 }
 ```
 
@@ -275,7 +335,7 @@ Parameter  | Default | Description
 > Get a list of available export formats
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/'
 ```
 
 The endpoint allows to download all datasets for a requested domain.
@@ -303,7 +363,7 @@ A dataset catalog can be exported in different formats:
 > Export datasets in json format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/json'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/json'
 ```
 
 ##### HTTP Request
@@ -314,7 +374,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/json'
 > Export datasets in csv format using **,** as delimiter
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/csv?delimiter=,'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/csv?delimiter=,'
 ```
 
 In the CSV format, the default separator is `;`. It can be changed with the `delimiter` parameter.
@@ -334,7 +394,7 @@ Parameter | Default | Description
 > Export datasets in xls format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/xls'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/xls'
 ```
 
 Export datasets to an XLS format using [SpreadsheetML specification](https://en.wikipedia.org/wiki/SpreadsheetML).
@@ -347,7 +407,7 @@ Export datasets to an XLS format using [SpreadsheetML specification](https://en.
 > Export datasets in rss format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/rss'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/rss'
 ```
 
 ##### HTTP Request
@@ -358,7 +418,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/rss'
 > Export datasets in turle rdf format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/ttl'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/ttl'
 ```
 
 Export datasets to a Turtle RDF format using [DCAT application for data portals in Europe](https://joinup.ec.europa.eu/asset/dcat_application_profile/description).
@@ -371,7 +431,7 @@ Export datasets to a Turtle RDF format using [DCAT application for data portals 
 > Export datasets in rdf-xml format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/rdf'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/rdf'
 ```
 
 Export datasets to an XML-RDF format using [DCAT application for data portals in Europe](https://joinup.ec.europa.eu/asset/dcat_application_profile/description).
@@ -384,7 +444,7 @@ Export datasets to an XML-RDF format using [DCAT application for data portals in
 > Export datasets in data.json format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/data.json'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/data.json'
 ```
 
 Export datasets in the [Project Open Data Metadata Schema v1.1](https://project-open-data.cio.gov/) (data.json).
@@ -398,7 +458,7 @@ Export datasets in the [Project Open Data Metadata Schema v1.1](https://project-
 > Export datasets in DCAT-AP DE format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/dcat_ap_de'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/dcat_ap_de'
 ```
 
 Export datasets in an RDF format, using DCAT application specific to Germany.
@@ -414,7 +474,7 @@ Export datasets in an RDF format, using DCAT application specific to Germany.
 > Export datasets in DCAT-AP CH format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/dcat_ap_ch'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/dcat_ap_ch'
 ```
 
 Export datasets in an RDF format, using DCAT application specific to Switzerland.
@@ -430,7 +490,7 @@ Export datasets in an RDF format, using DCAT application specific to Switzerland
 > Export datasets in DCAT-AP SE format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/dcat_ap_se'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/dcat_ap_se'
 ```
 
 Export datasets in an RDF format, using DCAT application specific to Sweden.
@@ -446,7 +506,7 @@ Export datasets in an RDF format, using DCAT application specific to Sweden.
 > Export datasets in DCAT-AP SP format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/exports/dcat_ap_sp'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/exports/dcat_ap_sp'
 ```
 
 Export datasets in an RDF format, using DCAT application specific to Spain.
@@ -459,13 +519,13 @@ Export datasets in an RDF format, using DCAT application specific to Spain.
 
 ## Looking up a dataset
 
-> Lookup Unesco dataset
+> Lookup the GeoNames dataset
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000'
 ```
 
-This endpoint allows to retrieve information about a specific datasets.
+This endpoint allows to retrieve information about a specific dataset.
 
 ##### HTTP Request
 `GET /api/v2/catalog/datasets/<dataset_id>`

--- a/source/includes/v2/_dataset.md
+++ b/source/includes/v2/_dataset.md
@@ -9,7 +9,7 @@ The dataset API allows to work on these records. More specifically, the dataset 
 - export records from a chosen dataset
 - lookup a specific record from a chosen dataset
 
-Each endpoint above is documented in its own section, along with its available parameters. Some of these parameters however accept field literals, which are documented right below. We recommend reading the **Field literal in dataset queries** section before diving into the dataset API.
+Each endpoint above is documented in its own section, along with its available parameters. Some of these parameters accept field literals. We recommend reading the **Field literal in dataset queries** section before diving into the dataset API.
 
 ##### Field literal in dataset queries
 
@@ -42,7 +42,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?select=name'
 ```
 
-Any field name from a dataset can be used as [field literal](#field-literal) in query parameters.
+Any field name from a dataset can be used as a [field literal](#field-literal) in query parameters.
 
 <aside>
 If a field name contains only numbers or is a keyword, it must be enclosed in back-quotes.
@@ -53,7 +53,7 @@ The list of fields for a specific dataset can be obtained with the [dataset look
 
 ## Searching records
 
-> Get first 10 records
+> Get the first 10 records
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?rows=10'
@@ -90,7 +90,7 @@ Parameter | Default | Description
 `exclude` | None | Exclude a given facet value from the result set (see [exclude in Facet documentation](#exclude))
 `start` | 0 | Index of the first item to return
 `rows` | 10 | Number of items to return.
-`include_app_metas` | false | Explicitely request application metadata for each dataset
+`include_app_metas` | false | Explicitly request application metadata for each dataset
 `timezone` | UTC | Timezone applied on datetime fields in query and response
 
 <aside>
@@ -125,7 +125,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/aggregates?select=count(*) as num_cities,country_code,sum(population) as sum_population&group_by=country_code'
 ```
 
-> Returns an array with an object for each `feature` containing feature's name and number of datasets
+> Returns an array with an object for each `feature` containing the feature's name and number of datasets
 
 ```json
 {
@@ -178,7 +178,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 > Aggregation with an multiple group_by
 
 ```shell
-# Retrieve number of cities with more than 5,000 inhabitatnts grouped by time zone and country code
+# Retrieve the number of cities with more than 5,000 inhabitants grouped by time zone and country code
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/aggregates?select=timezone,country_code,count(*)&group_by=timezone,country_code'
 ```
 
@@ -223,8 +223,8 @@ An aggregation query returns a JSON array containing an object for each group cr
 Each JSON object contains a key/value pair for each `select` instruction.
 However, without the `group_by` parameter, it returns an array with only one object.
 
-`select` parameter can only be composed of aggregation function or by aggregated value.
-It means that literal field in select clause outside aggregation function must be present in `group_by` clauses.
+The `select` parameter can only be composed of an aggregation function or by aggregated value.
+It means that a literal field in a select clause outside aggregation function must be present in `group_by` clauses.
 
 If a query contains multiple `group_by` clauses, returned groups are combined together.
 
@@ -296,7 +296,7 @@ Export records to a [GeoJSON format](http://geojson.org/).
 
 ### Exporting records in JSON Lines
 
-> Export records in json lines format
+> Export records in JSON Lines format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/jsonl'
@@ -305,12 +305,12 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 ##### HTTP Request
 `GET /api/v2/catalog/datasets/<dataset_id>/exports/jsonl`
 
-Export records to a [NDJSON](http://ndjson.org/) (Json lines) format.
+Export records to a [NDJSON](http://ndjson.org/) (JSON Lines) format.
 The JSONlines format returns a record by line. It can be useful for streaming operations.
 
 ### Exporting records in CSV
 
-> Export records in csv format using **,** as delimiter
+> Export records in CSV format using **,** as delimiter
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/csv?delimiter=,'
@@ -330,7 +330,7 @@ Parameter | Default | Description
 
 ### Exporting records in XLS
 
-> Export records in xls format
+> Export records in XLS format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/xls'
@@ -357,7 +357,7 @@ Export datasets to a [Shapefile format](https://en.wikipedia.org/wiki/Shapefile)
 
 ### Exporting records in Turtle RDF
 
-> Export records in turle rdf format
+> Export records in Turtle RDF format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/turtle'
@@ -367,9 +367,9 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 `GET /api/v2/catalog/datasets/<dataset_id>/exports/turtle`
 
 
-### Exporting records in RDF-XML
+### Exporting records in RDF/XML
 
-> Export records in rdf-xml format
+> Export records in RDF/XML format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/rdfxml'
@@ -381,7 +381,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 
 ### Exporting records in N3 RDF
 
-> Export records in n3 rdf format
+> Export records in N3 RDF format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/n3'
@@ -392,7 +392,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 
 ### Exporting records in JSON-LD RDF
 
-> Export records in json-ld rdf format
+> Export records in JSON-LD RDF format
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/jsonld'
@@ -404,7 +404,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 
 ## Looking up a record
 
-> Lookup airbnb-listings dataset
+> Lookup GeoNames dataset
 
 ```shell
 

--- a/source/includes/v2/_dataset.md
+++ b/source/includes/v2/_dataset.md
@@ -20,7 +20,7 @@ In dataset search, a field literal can either be a technical field or a field fr
 
 ```shell
 # Sort records by their technical size
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_2013/records?sort=record_size'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?sort=record_size'
 ```
 
 Field name | Description
@@ -35,11 +35,11 @@ Field name | Description
 > Use a field name as field_literal
 
 ```shell
-#Use field_name `name` to restrict records where `name` is Jonathan
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_2013/records?where=name="Jonathan"'
+#Use field_name `name` to restrict records where `name` is Paris
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?where=name="Paris"'
 
 # Select only `name` column
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_2013/records?select=name'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?select=name'
 ```
 
 Any field name from a dataset can be used as [field literal](#field-literal) in query parameters.
@@ -56,19 +56,19 @@ The list of fields for a specific dataset can be obtained with the [dataset look
 > Get first 10 records
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_2013/records?rows=10'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?rows=10'
 ```
 
 > Get 10 records starting at the 10th result
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_2013/records?rows=10&start=10'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?rows=10&start=10'
 ```
 
 > Search datasets containing `noa` in their fields
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_2013/records?where="Noa"'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?where="Noa"'
 ```
 
 This endpoint provides a search facility in the dataset catalog.
@@ -103,7 +103,7 @@ The sum of `start` and `rows` parameters must not exceed 10000. Use the export A
 > Aggregation query without group_by
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_2013/aggregates?select=count(*) as count'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/aggregates?select=count(*) as count'
 ```
 
 > Returns an array with one element
@@ -112,7 +112,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_20
 {
     "aggregations": [
         {
-            "count": 2841
+            "count": 50335
         }
     ]
 }
@@ -121,8 +121,8 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/baby_names_nc_20
 > Aggregation query with a single group_by
 
 ```shell
-# Retrieve population, state name, number of cities for each state (for the 1000 largest cities in the US)
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/largest-us-cities/aggregates?select=count(*) as num_cities,state,sum(population) as sum_population&group_by=state'
+# Retrieve the total number of cities with more than 5,000 inhabitants, the country code, and the total population for each country code
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/aggregates?select=count(*) as num_cities,country_code,sum(population) as sum_population&group_by=country_code'
 ```
 
 > Returns an array with an object for each `feature` containing feature's name and number of datasets
@@ -130,17 +130,24 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/largest-us-citie
 ```json
 {
     "aggregations": [
+        /* ... */
         {
-            "state": "California",
-            "num_cities": 212,
-            "sum_population": 27910620
+            "num_cities": 1982,
+            "country_code": "FR",
+            "sum_population": 39549205
         },
+        /* ... */
         {
-            "state": "Texas",
-            "num_cities": 83,
-            "sum_population": 14836230
+            "num_cities": 7197,
+            "country_code": "US",
+            "sum_population": 243520909
         },
-        ...
+        /* ... */
+        {
+            "num_cities": 43,
+            "country_code": "ZW",
+            "sum_population": 4043922
+        }
     ]
 }
 ```
@@ -149,20 +156,65 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/largest-us-citie
 > Invalid aggregation with a selected field not present in group_by
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/largest-us-cities/aggregates?select=state'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/aggregates?select=country_code'
 ```
 
 > Valid aggregation with an aggregation function
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/largest-us-cities/aggregates?select=sum(population)'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/aggregates?select=sum(population)'
+```
+
+```json
+{
+    "aggregations": [
+        {
+            "sum(population)": 2992377919
+        }
+    ]
+}
 ```
 
 > Aggregation with an multiple group_by
 
 ```shell
-# Retrieve number of Unesco sites grouped by continent and cities
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/aggregates?select=continent_en,country_en,count(*)&group_by=continent_en,country_en'
+# Retrieve number of cities with more than 5,000 inhabitatnts grouped by time zone and country code
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/aggregates?select=timezone,country_code,count(*)&group_by=timezone,country_code'
+```
+
+```json
+{
+    "aggregations": [
+        /* ... */
+        {
+            "timezone": "America/Chicago",
+            "count(*)": 2013,
+            "country_code": "US"
+        },
+        {
+            "timezone": "America/Chihuahua",
+            "count(*)": 35,
+            "country_code": "MX"
+        },
+        /* ... */
+        {
+            "timezone": "Europe/Paris",
+            "count(*)": 1982,
+            "country_code": "FR"
+        },
+        {
+            "timezone": "Europe/Podgorica",
+            "count(*)": 25,
+            "country_code": "ME"
+        },
+        /* ... */
+        {
+            "timezone": "Pacific/Wallis",
+            "count(*)": 3,
+            "country_code": "WF"
+        }
+    ]
+}
 ```
 
 This endpoint provides an aggregation facility for records.
@@ -196,7 +248,7 @@ Parameter  | Default | Description
 > Get a list of available export formats
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports'
 ```
 
 This endpoint allows to download all records for a requested dataset.
@@ -220,10 +272,10 @@ Records can be exported in 10 different formats:
 
 ### Exporting records in JSON
 
-> Export records in json format
+> Export records in JSON format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/json'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/json'
 ```
 
 ##### HTTP Request
@@ -234,7 +286,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-u
 > Export records in GeoJSON format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/geojson'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/geojson'
 ```
 
 ##### HTTP Request
@@ -247,7 +299,7 @@ Export records to a [GeoJSON format](http://geojson.org/).
 > Export records in json lines format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/jsonl'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/jsonl'
 ```
 
 ##### HTTP Request
@@ -261,7 +313,7 @@ The JSONlines format returns a record by line. It can be useful for streaming op
 > Export records in csv format using **,** as delimiter
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/csv?delimiter=,'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/csv?delimiter=,'
 ```
 
 Export records to CSV format. Default separator is `;`. It can be changed with `delimiter` parameter.
@@ -281,7 +333,7 @@ Parameter | Default | Description
 > Export records in xls format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/xls'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/xls'
 ```
 
 Export records to an XLS format using [SpreadsheetML specification](https://en.wikipedia.org/wiki/SpreadsheetML).
@@ -295,7 +347,7 @@ Export records to an XLS format using [SpreadsheetML specification](https://en.w
 > Export records to shapefile format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/shp'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/shp'
 ```
 
 Export datasets to a [Shapefile format](https://en.wikipedia.org/wiki/Shapefile).
@@ -308,7 +360,7 @@ Export datasets to a [Shapefile format](https://en.wikipedia.org/wiki/Shapefile)
 > Export records in turle rdf format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/turtle'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/turtle'
 ```
 
 ##### HTTP Request
@@ -320,7 +372,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-u
 > Export records in rdf-xml format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/rdfxml'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/rdfxml'
 ```
 
 ##### HTTP Request
@@ -332,7 +384,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-u
 > Export records in n3 rdf format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/n3'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/n3'
 ```
 
 ##### HTTP Request
@@ -343,7 +395,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-u
 > Export records in json-ld rdf format
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/exports/jsonld'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/exports/jsonld'
 ```
 
 ##### HTTP Request
@@ -356,8 +408,41 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-u
 
 ```shell
 
-# Get eiffel tower specific record from Unesco dataset
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets/world-heritage-unesco-list/records/0ef334837810f591330d1c6bc0e9289d00ff1c9d'
+# Get the record for Paris, the capital of France, from the GeoNames dataset
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records/d087227c3595eb1e5b7d09dacfdfd6cafb86562a'
+```
+
+```json
+{
+    "record": {
+        "id": "d087227c3595eb1e5b7d09dacfdfd6cafb86562a",
+        "timestamp": "2021-01-04T11:22:14.44Z",
+        "size": 1926,
+        "fields": {
+            "elevation": null,
+            "name": "Paris",
+            "modification_date": "2020-05-26",
+            "geonameid": "2988507",
+            "feature_class": "P",
+            "admin3_code": null,
+            "admin2_code": "75",
+            "geo_point_2d": {
+                "lat": 48.85341,
+                "lon": 2.3488
+            },
+            "cc2": null,
+            "timezone": "Europe/Paris",
+            "feature_code": "PPLC",
+            "dem": 42,
+            "country_code": "FR",
+            "admin1_code": "11",
+            "alternatenames": "Baariis,Bahliz,Ile-de-France,Lungsod ng Paris,Lutece,Lutetia,Lutetia Parisorum,Lutèce,PAR,Pa-ri,Paarys,Palika,Paname,Pantruche,Paraeis,Paras,Pari,Paries,Parigge,Pariggi,Parighji,Parigi,Pariis,Pariisi,Pariizu,Pariižu,Parij,Parijs,Paris,Parisi,Parixe,Pariz,Parize,Parizh,Parizh osh,Parizh',Parizo,Parizs,Pariž,Parys,Paryz,Paryzh,Paryzius,Paryż,Paryžius,Paräis,París,Paríž,Parîs,Parĩ,Parī,Parīze,Paříž,Páras,Párizs,Ville-Lumiere,Ville-Lumière,ba li,barys,pairisa,pali,pari,paris,parys,paryzh,perisa,pryz,pyaris,pyarisa,pyrs,Île-de-France,Παρίσι,Париж,Париж ош,Парижь,Париз,Парис,Парыж,Паріж,Փարիզ,פאריז,פריז,باريس,پارىژ,پاريس,پاریس,پیرس,ܦܐܪܝܣ,पॅरिस,पेरिस,पैरिस,প্যারিস,ਪੈਰਿਸ,પૅરિસ,பாரிஸ்,పారిస్,ಪ್ಯಾರಿಸ್,പാരിസ്,ปารีส,ཕ་རི།,ပါရီမြို့,პარიზი,ፓሪስ,ប៉ារីស,パリ,巴黎,파리",
+            "asciiname": "Paris",
+            "admin4_code": null,
+            "population": 2138551
+        }
+    }
+}
 ```
 
 This endpoint allows to retrieve information about a specific record.

--- a/source/includes/v2/_facets.md
+++ b/source/includes/v2/_facets.md
@@ -1,6 +1,6 @@
 # Facets
 
-A facet can be considered as a valued tag associated with a dataset or a record. For example, datasets of a catalog could have `language` as a facet: associated values for this facet could be `English` or `French`.
+A facet can be considered as a valued tag associated with a dataset or a record. For example, datasets of a catalog could have `language` as a facet: associated values for this facet could be `English`, `French`, or other languages (depending on the domain configuration and the publisher's choice).
 
 In an Opendatasoft portal, facets are specially used for building the left filtering column of both the datasets catalog and dataset records exploration pages.
 
@@ -8,7 +8,7 @@ In an Opendatasoft portal, facets are specially used for building the left filte
 
 Enumerating facets values allows to discover the existing values for a facet.
 
-For example, an API call to enumerate facets in a catalog can show that there are 12 datasets in English and 1 in French.
+For example, an API call to enumerate facets in a catalog can show that there are 11 datasets in English and 1 in French.
 
 ### Catalog
 
@@ -20,16 +20,6 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/facets'
 
 ```json
 {
-    "links": [
-        {
-            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/facets",
-            "rel": "self"
-        },
-        {
-            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog",
-            "rel": "source"
-        }
-    ],
     "facets": [
         /*...*/
         {

--- a/source/includes/v2/_facets.md
+++ b/source/includes/v2/_facets.md
@@ -1,6 +1,6 @@
 # Facets
 
-A facet can be considered as a valued tag associated with a dataset or a record. For example, datasets of a catalog could have `language` as facet: associated values for this facet could be `English`, `French` or `Swedish`.
+A facet can be considered as a valued tag associated with a dataset or a record. For example, datasets of a catalog could have `language` as facet: associated values for this facet could be `English` or `French`.
 
 In an Opendatasoft portal, facets are especially used for building the left filtering column of both the datasets catalog and dataset records exploration pages.
 
@@ -8,72 +8,103 @@ In an Opendatasoft portal, facets are especially used for building the left filt
 
 Enumerating facets values allows to discover the existing values for a facet.
 
-For example, an API call to enumerate facets in a catalog can show that there are 13 datasets in English, 10 in French and 2 in Swedish.
+For example, an API call to enumerate facets in a catalog can show that there are 12 datasets in English, and 1 in French.
 
 ### Catalog
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/facets'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/facets'
 ```
 
 > API Response
 
 ```json
 {
-    /*...*/
-  "facets": [
-    {
-      "name": "language",
-      "facets": [
+    "links": [
         {
-          "count": 13,
-          "state": "displayed",
-          "name": "en",
-          "value": "en"
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/facets",
+            "rel": "self"
         },
         {
-          "count": 10,
-          "state": "displayed",
-          "name": "fr",
-          "value": "fr"
-        },
-        {
-          "count": 2,
-          "state": "displayed",
-          "name": "sv",
-          "value": "sv"
-        },
-      ]
-    },
-    {
-      "name": "modified",
-      "facets": [
-        {
-          "count": 25,
-          "state": "displayed",
-          "name": "2019",
-          "value": "2019"
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog",
+            "rel": "source"
         }
-      ]
-    },
-    {
-      "name": "federated",
-      "facets": [
+    ],
+    "facets": [
+        /*...*/
         {
-          "count": 8,
-          "state": "displayed",
-          "name": "false",
-          "value": "false"
+            "name": "language",
+            "facets": [
+                {
+                    "count": 7,
+                    "state": "displayed",
+                    "name": "en",
+                    "value": "en"
+                },
+                {
+                    "count": 1,
+                    "state": "displayed",
+                    "name": "fr",
+                    "value": "fr"
+                }
+            ]
         },
         {
-          "count": 17,
-          "state": "displayed",
-          "name": "true",
-          "value": "true"
-        }
-      ]
-    }
-  ]
+            "name": "modified",
+            "facets": [
+                {
+                    "count": 8,
+                    "state": "refined",
+                    "name": "2020",
+                    "value": "2020",
+                    "facets": [
+                        {
+                            "count": 2,
+                            "state": "displayed",
+                            "name": "11",
+                            "value": "2020/11"
+                        },
+                        {
+                            "count": 6,
+                            "state": "displayed",
+                            "name": "12",
+                            "value": "2020/12"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "theme",
+            "facets": [
+                {
+                    "count": 2,
+                    "state": "displayed",
+                    "name": "Culture, Heritage",
+                    "value": "Culture, Heritage"
+                },
+                {
+                    "count": 1,
+                    "state": "displayed",
+                    "name": "Administration, Government, Public finances, Citizenship",
+                    "value": "Administration, Government, Public finances, Citizenship"
+                },
+                {
+                    "count": 1,
+                    "state": "displayed",
+                    "name": "Environment",
+                    "value": "Environment"
+                },
+                {
+                    "count": 1,
+                    "state": "displayed",
+                    "name": "Spatial planning, Town planning, Buildings, Equipment, Housing",
+                    "value": "Spatial planning, Town planning, Buildings, Equipment, Housing"
+                }
+            ]
+        },
+        /*...*/
+    ]
 }
 ```
 
@@ -111,44 +142,61 @@ Parameter  | Default | Multiple | Description
 
 Filtering facets values allows to limit the result set, either by refining or excluding.
 
-For example, an API call that enumerates the facets in a catalog can be refined to limit the result set to English datasets only. The subsequent call will show that among the 13 datasets of the catalog that are in English, 5 are federated datasets, and 8 aren't. It could then be possible to exclude federated datasets, etc.
+For example, an API call that enumerates the facets in a catalog can be refined to limit the result set to English datasets only. The subsequent call will show that among the 12 datasets of the catalog that are in English, only one dataset deals with environment. It could then be possible to exclude this dataset, etc.
 
 ### Refine
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/facets?refine=modified:2019'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/facets?refine=modified:2020'
 ```
 
 ```json
 {
+    "links": [
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/facets",
+            "rel": "self"
+        },
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog",
+            "rel": "source"
+        }
+    ],
     "facets": [
+        /* ... */  
         {
             "name": "modified",
             "facets": [
                 {
-                    "name": "2019",
-                    "path": "2019",
-                    "count": 154,
+                    "count": 8,
                     "state": "refined",
+                    "name": "2020",
+                    "value": "2020",
                     "facets": [
                         {
-                            "name": "08",
-                            "path": "2019/08",
-                            "count": 74,
-                            "state": "displayed"
+                            "count": 2,
+                            "state": "displayed",
+                            "name": "11",
+                            "value": "2020/11"
                         },
-                        /* ... */
+                        {
+                            "count": 6,
+                            "state": "displayed",
+                            "name": "12",
+                            "value": "2020/12"
+                        }
                     ]
                 }
             ]
-        }
+        },
+        /* ... */
     ]
 }
 ```
 
 It is possible to limit the result set by refining on a given facet value.
 
-For example, when using `refine=modified:2019`, only datasets modified in 2019 will be returned.
+For example, when using `refine=modified:2020`, only datasets modified in 2020 will be returned.
 
 #### Format:
 
@@ -162,7 +210,7 @@ For date, and other hierarchical facets, when refining on one value, all second-
 
 Using the same principle as above, it is possible to exclude a given facet value from the result set.
 
-For example, when using `exclude=modified:2019`, only results that have not been modified in 2019 will be returned. Facets enumeration will display 2019 as `excluded` without any count information.
+For example, when using `exclude=modified:2020`, only results that have not been modified in 2020 will be returned. Facets enumeration will display 2020 as `excluded` without any count information.
 
 #### Format:
 

--- a/source/includes/v2/_facets.md
+++ b/source/includes/v2/_facets.md
@@ -1,14 +1,14 @@
 # Facets
 
-A facet can be considered as a valued tag associated with a dataset or a record. For example, datasets of a catalog could have `language` as facet: associated values for this facet could be `English` or `French`.
+A facet can be considered as a valued tag associated with a dataset or a record. For example, datasets of a catalog could have `language` as a facet: associated values for this facet could be `English` or `French`.
 
-In an Opendatasoft portal, facets are especially used for building the left filtering column of both the datasets catalog and dataset records exploration pages.
+In an Opendatasoft portal, facets are specially used for building the left filtering column of both the datasets catalog and dataset records exploration pages.
 
 ## Enumerating facets values
 
 Enumerating facets values allows to discover the existing values for a facet.
 
-For example, an API call to enumerate facets in a catalog can show that there are 12 datasets in English, and 1 in French.
+For example, an API call to enumerate facets in a catalog can show that there are 12 datasets in English and 1 in French.
 
 ### Catalog
 
@@ -142,7 +142,7 @@ Parameter  | Default | Multiple | Description
 
 Filtering facets values allows to limit the result set, either by refining or excluding.
 
-For example, an API call that enumerates the facets in a catalog can be refined to limit the result set to English datasets only. The subsequent call will show that among the 12 datasets of the catalog that are in English, only one dataset deals with environment. It could then be possible to exclude this dataset, etc.
+For example, an API call that enumerates the facets in a catalog can be refined to limit the result set to English datasets only. The subsequent call will show that among the 12 datasets of the catalog that are in English, only one dataset deals with the environment. It could then be possible to exclude this dataset, etc.
 
 ### Refine
 

--- a/source/includes/v2/_introduction.md
+++ b/source/includes/v2/_introduction.md
@@ -15,5 +15,5 @@ The Opendatasoft search API v2 is organized around REST. It provides access to a
 - The same internal query language is used for all endpoints of the search API. It means that most of the time, parameters work the same way for all endpoints.
 
 <aside>
-The domain <a href="https://documentation-resources.opendatasoft.com/">https://documentation-resources.opendatasoft.com/</a> is used as an example in this documentation, but you should replace it with your custom domain name.
+The domain <a target="_blank" rel="noopener noreferrer" href="https://documentation-resources.opendatasoft.com/">https://documentation-resources.opendatasoft.com/</a> is used as an example in this documentation. You should replace it with your custom domain name,  or `data.opendatasoft.com`, which is the main hub for all open data portals published by Opendatasoft customers. It contains a lot of ready-to-play interesting datasets.
 </aside>

--- a/source/includes/v2/_introduction.md
+++ b/source/includes/v2/_introduction.md
@@ -1,9 +1,9 @@
 # Search API v2
 
-> Search API endpoint for examples domain
+> Search API endpoint for the `documentation-resources` domain
 
 ```text
-https://examples.opendatasoft.com/api/v2
+https://documentation-resources.opendatasoft.com/api/v2
 ```
 
 The Opendatasoft search API v2 is organized around REST. It provides access to all the data available through the platform in a coherent, hierarchical way.
@@ -15,5 +15,5 @@ The Opendatasoft search API v2 is organized around REST. It provides access to a
 - The same internal query language is used for all endpoints of the search API. It means that most of the time, parameters work the same way for all endpoints.
 
 <aside>
-The domain https://examples.opendatasoft.com/ will be used by default in all the examples of this documentation.
+The domain <a href="https://documentation-resources.opendatasoft.com/">https://documentation-resources.opendatasoft.com/</a> is used as an example in this documentation, but you should replace it with your custom domain name.
 </aside>

--- a/source/includes/v2/_metadata.md
+++ b/source/includes/v2/_metadata.md
@@ -14,7 +14,7 @@ Each metadata belongs to a metadata template. There are 3 different types of met
 > List metadata template types
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates'
 ```
 
 > API response:
@@ -22,23 +22,23 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates'
 ```json
 {
 	"links": [{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates",
 			"rel": "self"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/interop",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/interop",
 			"rel": "Interoperatibility"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
 			"rel": "Basic"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/extra",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/extra",
 			"rel": "Extra"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/admin",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/admin",
 			"rel": "Admin"
 		}
 	]
@@ -57,7 +57,7 @@ This endpoint returns the list of all available metadata template types.
 > List templates for `basic` type
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic'
 ```
 
 > API response:
@@ -65,17 +65,17 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic'
 ```json
 {
 	"links": [{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
 			"rel": "self"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates",
 			"rel": "metadata_templates"
 		}
 	],
 	"metadata_templates": [{
 		"links": [{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default",
 			"rel": "self"
 		}],
 		"matadata_template": {
@@ -107,7 +107,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic'
 					"type": "longstring",
 					"values_domain_property": null
 				},
-                ...
+                /* ... */
 			]
 		}
 	}]
@@ -126,7 +126,7 @@ This endpoint returns the list of existing metadata templates for a chosen type.
 > List metadata for `default` template
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default'
 ```
 
 
@@ -135,15 +135,15 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic/
 ```json
 {
 	"links": [{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default",
 			"rel": "self"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
 			"rel": "basic"
 		},
 		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog/metadata_templates",
+			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates",
 			"rel": "metadata_templates"
 		}
 	],
@@ -189,7 +189,7 @@ curl 'https://examples.opendatasoft.com/api/v2/catalog/metadata_templates/basic/
 				"type": "list",
 				"values_domain_property": "metadata.themes"
 			},
-            ...
+            /* ... */
 		]
 	}
 }

--- a/source/includes/v2/_metadata.md
+++ b/source/includes/v2/_metadata.md
@@ -64,21 +64,12 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_t
 
 ```json
 {
-	"links": [{
-			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
-			"rel": "self"
-		},
-		{
-			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates",
-			"rel": "metadata_templates"
-		}
-	],
 	"metadata_templates": [{
 		"links": [{
 			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default",
 			"rel": "self"
 		}],
-		"matadata_template": {
+		"metadata_template": {
 			"type": "basic",
 			"name": "default",
 			"schema": [{
@@ -134,19 +125,6 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_t
 
 ```json
 {
-	"links": [{
-			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic/default",
-			"rel": "self"
-		},
-		{
-			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates/basic",
-			"rel": "basic"
-		},
-		{
-			"href": "https://documentation-resources.opendatasoft.com/api/v2/catalog/metadata_templates",
-			"rel": "metadata_templates"
-		}
-	],
 	"metadata_template": {
 		"type": "basic",
 		"name": "default",

--- a/source/includes/v2/_metadata.md
+++ b/source/includes/v2/_metadata.md
@@ -4,9 +4,9 @@ Metadata is data describing the dataset itself.
 
 Each metadata belongs to a metadata template. There are 3 different types of metadata template:
 
-- `basic`: metadata that users can see. For example, `basic` metadata include the dataset title, the license attached to it data, etc.
-- `interop` (for interoperability): metadata usually described in specific standards (e.g. DCAT, INSPIRE), intended for automatic usage by other systems, for interoperability purpose or for regulatory compliance.
-- `extra`: metadata intended for specific applications, and not expected to be used by users directly. For example, `extra` metadata contain information about default visualizations on the Opendatasoft portal.
+- `basic`: metadata that users can see. For example, `basic` metadata include the dataset title, the license attached to its data, etc.
+- `interop` (for interoperability): metadata usually described in specific standards (for example, DCAT, INSPIRE), intended for automatic usage by other systems, for interoperability purposes, or for regulatory compliance.
+- `extra`: metadata intended for specific applications and not expected to be used by users directly. For example, `extra` metadata contain information about default visualizations on the Opendatasoft portal.
 
 
 ## Listing metadata template types

--- a/source/includes/v2/_odsql.md
+++ b/source/includes/v2/_odsql.md
@@ -1,24 +1,24 @@
 # ODSQL
 
-Filtering features are built in the core of Opendatasoft API engine.
+Filtering features are built in the core of the Opendatasoft API engine.
 
 The Opendatasoft Query Language (ODSQL) makes it possible to express complex queries as a filtering context for datasets or records, but also to build aggregations or computed fields.
 
-Note that a given filtering context can simply be copied from one API to another. For example, it is possible to build a user interface which first allows the user to visually select the records they are are interested in, using full text search, facets and geo filtering ; and then allowing them to download these records with the same filtering context.
+Note that a given filtering context can simply be copied from one API to another. For example, it is possible to build a user interface that first allows the user to visually select the records they are interested in, using full-text search, facets, and geo filtering; and then allowing them to download these records with the same filtering context.
 
 ## Introduction
 
 The ODSQL is split into 5 different kinds of clauses:
 
-- the `select` clause: it allows choosing the returned fields, to give them an alias, or to manipulate them with functions like count, sum, min, max, etc.
+- the `select` clause: it allows choosing the returned fields, giving them an alias, manipulating them with functions like count, sum, min, max, etc.
 - the `where` clause: it acts as a filter for the returned datasets or records, thanks to boolean operations, filter functions, arithmetic expressions, etc.
 - the `group by` clause: it allows aggregating rows together based on fields, numeric ranges, or dates
 - the `order by` and `limit` clauses: they allow choosing the order and quantity of rows received as a response
 
-These clauses are used as parameters in the Search API v2 for searching, aggregating and exporting datasets and records. Depending on the used endpoint, some features of the query language are available or not in the request.
+These clauses are used as parameters in the Search API v2 for searching, aggregating, and exporting datasets and records. Depending on the used endpoint, some features of the query language are available or not in the request.
 
 <aside>
-The whole query language is case insensitive and spaces are optional. In this documentation, upper case will however be used for language keywords, only for clarity purpose.
+The whole query language is case insensitive, and spaces are optional. In this documentation, the uppercase is used for language keywords, only for clarity purposes.
 </aside>
 
 
@@ -28,7 +28,7 @@ ODSQL clauses are composed of basic language elements. These can either be liter
 
 ### Literals in ODSQL clauses
 
-Literals are used in comparison, assignments or functions.
+Literals are used in comparison, assignments, or functions.
 
 There are 7 types of literal:
 
@@ -50,7 +50,7 @@ my_field > 10  -- my_field is a string literal
 `and`: "value" -- AND is a keyword
 ```
 
-A field literals is a literal not enclosed in quotes. It can only contain alphanumeric characters or underscores.
+A field literal is a literal not enclosed in quotes. It can only contain alphanumeric characters or underscores.
 
 <aside>
 If a field name contains only numbers or is a keyword, it must be enclosed in back-quotes.
@@ -97,7 +97,7 @@ A date literal is defined with a date keyword followed by a valid date format en
 A valid date can be:
 
 - an [ISO 8601 date](https://en.wikipedia.org/wiki/ISO_8601)
-- a slash separated date in the YYYY/MM/DD (year/month/day) format
+- a slash-separated date in the YYYY/MM/DD (year/month/day) format
 
 <div class=“clearfix”></div>
 #### Boolean literal
@@ -121,7 +121,7 @@ distance(my_geo_field, geom'POINT(1 1)', 10km)
 geometry(my_geo_field, geom'{"type": "Polygon","coordinates":[[[100.0, 0.0],[101.0, 0.0],[101.0, 1.0],[100.0, 1.0],[100.0,0.0]]]}')
 ```
 
-A geometry literal is defined with a geom keyword followed by a valid geometry expression enclosed in single quotes.
+A geometry literal is defined with a `geom` keyword followed by a valid geometry expression enclosed in single quotes.
 
 Supported geometry expressions are:
 
@@ -149,10 +149,10 @@ Function|Parameters|Description|Limitation
 <div class=“clearfix”></div>
 ### Reserved keywords in ODSQL clauses
 
-> `not` is a reserved keywords and must be escaped with back-quotes if referred as field literal
+> `not` is a reserved keyword and must be escaped with back-quotes if referred to as a field literal
 
 ```sql
-my_field_literal is not true -- my_field_literal is not a reserved keyword, no need to escape it
+my_field_literal is not true -- my_field_literal is not a reserved keyword, there's no need to escape it
 `not` is not true -- not is a reserved keyword and must be escaped
 ```
 
@@ -201,7 +201,7 @@ List of reserved keywords:
 
 The select clause can be used in records search APIs as the parameter `select`.
 
-The select clause allows :
+The select clause allows:
 - choosing the fields that will be returned for each row,
 - transforming fields using arithmetic,
 - renaming fields,
@@ -226,12 +226,12 @@ A select expression can be:
 
 ```sql
 *                           -- Select all fields
-field1, field2, field3      -- Only select field1, field2 and field3
+field1, field2, field3      -- Only select field1, field2, and field3
 field1 AS my_field, field2  -- Renaming field1 as my_field and select field2
 ```
 
 A select field literal is the simplest form of select expression. It takes a field literal that must be returned in the result.
-It also accepts the special character `*` to select all fields (it is the default behaviour).
+It also accepts the special character `*` to select all fields (it is the default behavior).
 
 <aside>
 If a select expression is used in conjunction with a `group by` clause, the selected field literal must be in the `group by` clause.
@@ -250,7 +250,7 @@ include(pop*) -- Will include fields beginning with pop
 
 Include and exclude are functions that accept fields names.
 
-Fields listed in an include function are present in the result whereas fields listed in an exclude function are absent from the result.
+Fields listed in an include function are present in the result, whereas fields listed in an exclude function are absent from the result.
 
 Fields can contain a wildcard suffix (the `*` character). In that case, the inclusion/exclusion works on all field names beginning with the value preceding the wildcard.
 
@@ -267,7 +267,7 @@ Fields can contain a wildcard suffix (the `*` character). In that case, the incl
 length(country_name) -- Get length (number of characters) of country_name field values
 ```
 
-An arithmetic select expression accepts simple arithmetic operations. It accepts field literals, constant numeric or text values and [scalar functions](#scalar-functions). More complex arithmetic expressions can be formed by connecting these elements with arithmetic operators:
+An arithmetic select expression accepts simple arithmetic operations. It accepts field literals, constant numeric or text values, and [scalar functions](#scalar-functions). More complex arithmetic expressions can be formed by connecting these elements with arithmetic operators:
 
  - `+`: add
  - `-`: substract
@@ -309,7 +309,7 @@ This function computes numbers of elements.
 
 It accepts the following parameters:
   - a field literal: only returns the count for not `null` value of this field
-  - a `*` : returns the count of all elements
+  - a `*`: returns the count of all elements
 
 
 <div class=“clearfix”></div>
@@ -377,7 +377,7 @@ This function takes a numeric field literal and a percentile. It returns the nth
 median(age) as med # Return the median of the age field
 ```
 
-This function takes a numeric field literal. It returns the median (`median`) of this field. Since the median is in fact the 50th percentile, it is a shortcut for `percentile(field, 50)`.
+This function takes a numeric field literal. It returns the median (`median`) of this field. Since the median is the 50th percentile, it is a shortcut for `percentile(field, 50)`.
 
 
 ## Where clause
@@ -390,7 +390,7 @@ my_numeric_field > 10 and my_text_field like "paris" or distance(my_geo_field, g
 
 > This where clause filters results where numeric_field > 10 and (my_text_field contains the word `paris` or distance between my_geo_field and the point with 1,1 as lat,lon is under 1 kilometer)
 
-The where clause can be used in the whole search API as the parameter `where`.
+The where clause can be used in the whole Search API as the parameter `where`.
 
 The where clause allows one to filter rows with a combination of where expressions.
 
@@ -418,15 +418,15 @@ my_boolean_field OR my_numeric_field > 50 and my_date_field > date'1972'
 
 Where expressions can use boolean operators to express boolean filter.
 
-There are 3 different boolan operations:
+There are 3 different boolean operations:
 
 - `AND`: results must match left and right expressions
 - `OR`: results must match left or right expression
 - `NOT`: inverses the next expression
 
-`AND` has precedence over `OR` operator. It means that, in the expression `a or b and c`, the sub-expression `b and c` is interpreted and executed first. It can also be written with parenthesis: `a or (b and c)`.
+`AND` has precedence over the `OR` operator. It means that, in the expression `a or b and c`, the sub-expression `b and c` is interpreted and executed first. It can also be written with parenthesis: `a or (b and c)`.
 
-In order to change operator precedence, it is possible to use parenthesis in the expression. To give precedence to `OR` operator, the above expression can be written `(a or b) and c`.
+In order to change operator precedence, it is possible to use parenthesis in the expression. To give precedence to the `OR` operator, the above expression can be written `(a or b) and c`.
 
 
 <div class=“clearfix”></div>
@@ -455,7 +455,7 @@ NOT "dog"
 "film*"      -- returns results that contain film, films, filmography, etc.
 ```
 
-Filter search queries are queries that don’t refer to fields, they only contain quoted strings and boolean operators. Filter search queries perform full-text searches on all visible fields of each record and return matching rows.
+Filter search queries are queries that don’t refer to fields. They only contain quoted strings and boolean operators. Filter search queries perform full-text searches on all visible fields of each record and return matching rows.
 
 If the string contains more than one word, the query will be an `AND` query on each tokenized word.
 
@@ -485,7 +485,7 @@ distance(field_name, GEOM'<geometry>', 100yd)
 The distance function limits the result set to a geographical area defined by a circle. This circle must be defined by its center and a distance.
 
 - The center of the circle is expressed as a [geometry literal](#geometry-literal)).
-- The distance is numeric and can have an unit in:
+- The distance is numeric and can have a unit in:
 
   - miles (mi)
   - yards (yd)
@@ -547,7 +547,7 @@ bbox(field_name, GEOM'<geometry>', GEOM'<geometry>')
 
 The bbox function limits the result set to a rectangular box.
 
-This rectangular box is defined by its top left and its bottom right coordinates, both expressed with 2 [geometry literals](#geometry-literal).
+This rectangular box is defined by its top-left and its bottom-right coordinates, both expressed with 2 [geometry literals](#geometry-literal).
 
 <div class=“clearfix”></div>
 ### Comparison filter
@@ -626,7 +626,7 @@ film_name like "star"      -- matches `star wars` and `Star Trek`
 film_name like "star wars" -- match fields containing `star` and `wars`
 ```
 
-A like filter restricts results to field literal values containing a defined string literal.
+A `like` filter restricts results to field literal values containing a defined string literal.
 
 ##### Format:
 `<field_literal> LIKE <string_literal>`
@@ -865,7 +865,7 @@ date_format(date_field, "w") -- Create a group for each different week in date_f
 A group by date format expression allows grouping by a custom date format.
 
 A `date format` is a string enclosed in double-quotes.
-Every character between a-z and A-Z is considered to be a pattern representing a date unit. In order to use these characters as simple characters and not pattern, they must be enclosed in single-quotes.
+Every character between a-z and A-Z is considered to be a pattern representing a date unit. In order to use these characters as simple characters and not as patterns, they must be enclosed in single-quotes.
 
 The formats below are available for a date format expression. They come from [joda time documentation](http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html).
 
@@ -971,6 +971,6 @@ An order by expression can be :
 The direction, if not specified, is by default ASC (ascending).
 
 <aside>
-When ordering by both aggregations and fields, the aggregation order must be in head of the list.
+When ordering by both aggregations and fields, the aggregation order must be at the head of the list.
 For example : <code>order_by = avg(age), gender</code> works, but <code>order_by = gender, avg(age)</code> returns an error.
 </aside>

--- a/source/includes/v2/_sources.md
+++ b/source/includes/v2/_sources.md
@@ -3,30 +3,31 @@
 > Retrieve a list of available sources on `public` domain
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/'
 ```
 
 > The above command returns
 
 ```json
 {
-	"links": [{
-			"href": "https://examples.opendatasoft.com/api/v2",
-			"rel": "self"
-		},
-		{
-			"href": "https://examples.opendatasoft.com/api/v2/catalog",
-			"rel": "catalog"
-		},
-		{
-			"href": "https://examples.opendatasoft.com/api/v2/monitoring",
-			"rel": "monitoring"
-		},
-		{
-			"href": "https://examples.opendatasoft.com/api/v2/opendatasoft",
-			"rel": "opendatasoft"
-		}
-	]
+    "links": [
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2",
+            "rel": "self"
+        },
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/catalog",
+            "rel": "catalog"
+        },
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/monitoring",
+            "rel": "monitoring"
+        },
+        {
+            "href": "https://documentation-resources.opendatasoft.com/api/v2/opendatasoft",
+            "rel": "opendatasoft"
+        }
+    ]
 }
 ```
 
@@ -48,7 +49,7 @@ For now, the metadata API only works on the catalog data source.
 > Get a list of published datasets on `public` domain
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/catalog/datasets'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets'
 ```
 
 The catalog source works on the published dataset of a requested domain. Use this source to retrieve actual data from a specific domain.
@@ -62,7 +63,7 @@ The catalog source works on the published dataset of a requested domain. Use thi
 > Get a list of monitoring datasets on `public` domain
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/monitoring/datasets'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/monitoring/datasets'
 ```
 
 The monitoring source allows to search and work on special datasets providing analysis information about a requested domain.
@@ -78,16 +79,16 @@ The monitoring API gives access to the data of one specific dataset containing t
 
 ## Opendatasoft source
 
-> Get a list of all public datasets on Opendatasoft Data Hub
+> Get a list of all public datasets on Opendatasoft's Data Network
 
 ```shell
-curl 'https://examples.opendatasoft.com/api/v2/opendatasoft/datasets'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/opendatasoft/datasets'
 ```
 
 The Opendatasoft allows to search and work on all available public datasets from the Opendatasoft data network.
 
 <aside>
-The HTTP request below returns the same datasets as `https//data.opendatasoft.com/api/v2/catalog`.
+The HTTP request below returns the same datasets as https//data.opendatasoft.com/api/v2/catalog.
 </aside>
 
 ##### HTTP Request

--- a/source/includes/v2/_sources.md
+++ b/source/includes/v2/_sources.md
@@ -1,6 +1,6 @@
 # Sources
 
-> Retrieve a list of available sources on `public` domain
+> Retrieve a list of available sources on the `documentation-resource` domain
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/'
@@ -46,7 +46,7 @@ For now, the metadata API only works on the catalog data source.
 
 ## Catalog source
 
-> Get a list of published datasets on `public` domain
+> Get a list of published datasets on the `documentation-resource` domain
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets'
@@ -60,7 +60,7 @@ The catalog source works on the published dataset of a requested domain. Use thi
 
 ## Monitoring source
 
-> Get a list of monitoring datasets on `public` domain
+> Get a list of monitoring datasets on the `documentation-resource` domain
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/monitoring/datasets'
@@ -79,16 +79,16 @@ The monitoring API gives access to the data of one specific dataset containing t
 
 ## Opendatasoft source
 
-> Get a list of all public datasets on Opendatasoft's Data Network
+> Get a list of all public datasets on the Opendatasoft Data Network
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/opendatasoft/datasets'
 ```
 
-The Opendatasoft allows to search and work on all available public datasets from the Opendatasoft data network.
+The Opendatasoft source allows to search and work on all available public datasets from the Opendatasoft Data Network.
 
 <aside>
-The HTTP request below returns the same datasets as https//data.opendatasoft.com/api/v2/catalog.
+The following HTTP request returns the same datasets as https//data.opendatasoft.com/api/v2/catalog.
 </aside>
 
 ##### HTTP Request

--- a/source/includes/v2/_sources.md
+++ b/source/includes/v2/_sources.md
@@ -79,13 +79,13 @@ The monitoring API gives access to the data of one specific dataset containing t
 
 ## Opendatasoft source
 
-> Get a list of all public datasets on the Opendatasoft Data Network
+> Get a list of all public datasets on Opendatasoft's Data Network
 
 ```shell
 curl 'https://documentation-resources.opendatasoft.com/api/v2/opendatasoft/datasets'
 ```
 
-The Opendatasoft source allows to search and work on all available public datasets from the Opendatasoft Data Network.
+The Opendatasoft source allows to search and work on all available public datasets from Opendatasoft's Data Network.
 
 <aside>
 The following HTTP request returns the same datasets as https//data.opendatasoft.com/api/v2/catalog.


### PR DESCRIPTION
## Summary

This PR updates all examples based on different domains to examples based on the `documentation-resources` domain.

Story details: https://app.clubhouse.io/opendatasoft/story/26016

## Changes

- Updated examples in Search API v2 docs with paths and datasets from `documentation-resources`. The [Geonames Cities with population > 5000](https://documentation-resources.opendatasoft.com/explore/dataset/doc-geonames-cities-5000/table/) dataset is now used to show request and response examples.
- Fixed typos and grammar issues.