### PR TITLE
Update the examples in the Search API v1 docs

### DIFF
--- a/source/includes/v1/available_apis.md
+++ b/source/includes/v1/available_apis.md
@@ -2,7 +2,7 @@
 
 Opendatasoft datasets are accessible by developers through an HTTP REST API.
 
-The domain <https://examples.opendatasoft.com> will be used to illustrate examples given in the following documentation.
+The domain <https://documentation-resources.opendatasoft.com> is used to illustrate examples in the following documentation.
 
 ![API Console](v1/available_apis__console.png)
 
@@ -70,7 +70,7 @@ The API response contains three headers to indicate the current state of a user'
 > Example of an error occurring when you reach the domain requests limit
 
 ``` http
-> GET https://examples.opendatasoft.com/api/datasets/1.0/search/ HTTP/1.1
+> GET https://documentation-resources.opendatasoft.com/api/datasets/1.0/search/ HTTP/1.1
 
 < HTTP/1.0 429 TOO MANY REQUESTS
 ```
@@ -78,7 +78,7 @@ The API response contains three headers to indicate the current state of a user'
 ``` json
 {
   "errorcode": 10002,
-  "reset_time": "2017-10-17T00:00:00Z",
+  "reset_time": "2021-01-26T00:00:00Z",
   "limit_time_unit": "day",
   "call_limit": 10000,
   "error": "Too many requests on the domain. Please contact the domain administrator."
@@ -88,7 +88,7 @@ The API response contains three headers to indicate the current state of a user'
 > Example of an error occurring when you reach the requests limit for anonymous users
 
 ``` http
-> GET https://examples.opendatasoft.com/api/datasets/1.0/search/ HTTP/1.1
+> GET https://documentation-resources.opendatasoft.com/api/datasets/1.0/search/ HTTP/1.1
 
 < HTTP/1.0 429 TOO MANY REQUESTS
 ```
@@ -96,7 +96,7 @@ The API response contains three headers to indicate the current state of a user'
 ``` json
 {
   "errorcode": 10005,
-  "reset_time": "2017-10-17T00:00:00Z",
+  "reset_time": "2021-01-26T00:00:00Z",
   "limit_time_unit": "day",
   "call_limit": 1000,
   "error": "You have exceeded the requests limit for anonymous users."

--- a/source/includes/v1/catalog_api.md
+++ b/source/includes/v1/catalog_api.md
@@ -6,15 +6,15 @@
 GET /api/datasets/1.0/search HTTP/1.1
 ```
 
-> Example Dataset Search Queries
+> Examples of Dataset Search Queries
 
 ```text
 https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?refine.language=en&refine.modified=2021/01
 https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?exclude.publisher=GeoNames&sort=-modified
 ```
 
-This API provides a search facility in the dataset catalog. Full text search as well as multi-criteria field queries
-are made possible and results facetting is provided as well.
+This API provides a search facility in the dataset catalog. Full-text search as well as multi-criteria field queries
+are made possible, and results facetting is provided as well.
 
 ### Parameters
 
@@ -24,8 +24,8 @@ Parameter         | Description
 `facet`           | Activate faceting on the specified field (see list of fields in the [Query Language](#field-queries) section). This parameter can be used multiple times to activate several facets. By default, faceting is disabled
 `refine.<FACET>`  | Limit the result set to records where `FACET` has the specified value. It can be used several times for the same facet or for different facets
 `exclude.<FACET>` | Exclude records where `FACET` has the specified value from the result set. It can be used several times for the same facet or for different facets
-`sort`            | Sorts results by the specified field. By default, the sort is descending. A minus sign `-` may be used to perform an ascending sort. Sorting is only available on numeric fields (Integer, Decimal), date fields (Date, DateTime) and on text fields which have the `sortable`  annotation
-`rows`            | Number of results to return in a single call. By default, `10` results are returned. While you can request for up to `10 000` results in a row, such requests are not optimal and can be throttled so you should consider splitting them into smaller ones.
+`sort`            | Sorts results by the specified field. By default, the sort is descending. A minus sign `-` may be used to perform an ascending sort. Sorting is only available on numeric fields (Integer, Decimal), date fields (Date, DateTime), and on text fields that have the `sortable`  annotation
+`rows`            | Number of results to return in a single call. By default, `10` results are returned. While you can request up to `10 000` results in a row, such requests are not optimal and can be throttled. So, you should consider splitting them into smaller ones.
 `start`           | Index of the first result to return (starting at 0). Use in conjunction with `rows` to implement paging
 `pretty_print`    | If set to true (default is false), pretty prints JSON and JSONP output
 `format`          | Format of the response output. Can be `json` (default), `jsonp`, `csv` or `rss`
@@ -37,7 +37,7 @@ Parameter         | Description
 GET /api/datasets/1.0/<dataset_id> HTTP/1.1
 ```
 
-> Example Dataset Lookup API URL
+> Example of Dataset Lookup API URL
 
 ```text
 https://documentation-resources.opendatasoft.com/api/datasets/1.0/doc-geonames-cities-5000/?pretty_print=true&format=json

--- a/source/includes/v1/catalog_api.md
+++ b/source/includes/v1/catalog_api.md
@@ -9,8 +9,8 @@ GET /api/datasets/1.0/search HTTP/1.1
 > Example Dataset Search Queries
 
 ```text
-https://examples.opendatasoft.com/api/datasets/1.0/search?refine.language=en&refine.modified=2017/10
-https://examples.opendatasoft.com/api/datasets/1.0/search?exclude.publisher=UNESCO&sort=-modified
+https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?refine.language=en&refine.modified=2021/01
+https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?exclude.publisher=GeoNames&sort=-modified
 ```
 
 This API provides a search facility in the dataset catalog. Full text search as well as multi-criteria field queries
@@ -40,13 +40,13 @@ GET /api/datasets/1.0/<dataset_id> HTTP/1.1
 > Example Dataset Lookup API URL
 
 ```text
-https://examples.opendatasoft.com/api/datasets/1.0/world-heritage-unesco-list/?pretty_print=true&format=json
+https://documentation-resources.opendatasoft.com/api/datasets/1.0/doc-geonames-cities-5000/?pretty_print=true&format=json
 ```
 
 > Example of JSONP request
 
 ```text
-https://examples.opendatasoft.com/api/datasets/1.0/world-heritage-unesco-list/?format=jsonp&callback=myFunction
+https://documentation-resources.opendatasoft.com/api/datasets/1.0/doc-geonames-cities-5000/?format=jsonp&callback=myFunction
 ```
 
 This API makes it possible to fetch an individual dataset information.

--- a/source/includes/v1/query_language_and_geo_filtering.md
+++ b/source/includes/v1/query_language_and_geo_filtering.md
@@ -42,10 +42,10 @@ Parenthesis can be used to group together expressions and alter the default prio
 
 ### Field queries
 
-> Search on https://public.opendatasoft.com for datasets having "Paris" in their title or description and containing at least 50 000 records
+> Search on the `documentation-resources` domain for datasets having "Paris" in their title or description and containing at least 50 records
 
 ``` text
-GET https://public.opendatasoft.com/api/datasets/1.0/search?q=(title:paris OR description:paris) AND records_count >= 50000
+GET https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?q=(title:paris OR description:paris) AND records_count >= 50
 ```
 
 One of the major feature of the query language is to allow per field filtering. You can use field names as a prefix to

--- a/source/includes/v1/query_language_and_geo_filtering.md
+++ b/source/includes/v1/query_language_and_geo_filtering.md
@@ -1,11 +1,11 @@
 # Query Language and Geo Filtering
 
-Filtering features are built in the core of Opendatasoft API engine. Many of the previously listed APIs can take as a
-parameter filters for constraining the list of returned datasets or records.
+Filtering features are built in the core of the Opendatasoft API engine. Many of the previously listed APIs can take as
+parameters filters for constraining the list of returned datasets or records.
 
 Note that a given filtering context can simply be copied from one API to another. For example, you can easily build a
-user interface which first allows the user to visually select the records their are interested in, using full text
-search, facets and geo filtering, and then allowing them to download these records with the same filtering context.
+user interface that first allows the user to visually select the records they are interested in, using full-text
+search, facets, and geo filtering, and then allowing them to download these records with the same filtering context.
 
 ## Query language
 
@@ -20,9 +20,9 @@ q=film -> results that contain film, films, filmography, etc.
 q="film" -> results containing exactly film.
 ```
 
-The query language accepts full text queries.
+The query language accepts full-text queries.
 
-If a given word or compounds is surrounded with double quotes, only exact matches are returned (modulo an accent and
+If a given word, or compounds, is surrounded with double quotes, only exact matches are returned (modulo an accent and
 case insensitive match).
 
 ### Boolean expressions
@@ -32,7 +32,7 @@ film OR trees
 (film OR trees) AND paris
 ```
 
-The query language supports the following boolean operators `AND`, `OR` and `NOT`.
+The query language supports the following boolean operators `AND`, `OR`, and `NOT`.
 
 Parenthesis can be used to group together expressions and alter the default priority model:
 
@@ -48,7 +48,7 @@ Parenthesis can be used to group together expressions and alter the default prio
 GET https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?q=(title:paris OR description:paris) AND records_count >= 50
 ```
 
-One of the major feature of the query language is to allow per field filtering. You can use field names as a prefix to
+One of the major features of the query language is to allow per field filtering. You can use field names as a prefix to
 your queries to filter the results based on a specific field's value.
 
 For the dataset search API, the list of available fields corresponds exactly to available metadata. By default
@@ -170,7 +170,7 @@ Function name | Description
 
 ## Geo Filtering
 
-> Example geo filtering expressions
+> Examples of geo filtering expressions
 
 ``` text
 geofilter.distance=48.8520930694,2.34738897685,1000

--- a/source/includes/v1/query_language_and_geo_filtering.md
+++ b/source/includes/v1/query_language_and_geo_filtering.md
@@ -1,7 +1,6 @@
 # Query Language and Geo Filtering
 
-Filtering features are built in the core of the Opendatasoft API engine. Many of the previously listed APIs can take as
-parameters filters for constraining the list of returned datasets or records.
+Filtering features are built in the core of the Opendatasoft API engine. Many of the previously listed APIs can take filters as parameters, so that the response only contains the datasets or records you want.
 
 Note that a given filtering context can simply be copied from one API to another. For example, you can easily build a
 user interface that first allows the user to visually select the records they are interested in, using full-text

--- a/source/includes/v1/records_api.md
+++ b/source/includes/v1/records_api.md
@@ -25,8 +25,8 @@ Parameter            | Description
 `pretty_print`       | If set to true (default is false), pretty prints JSON and JSONP output
 `format`             | Format of the response output. Can be `json` (default), `jsonp`, `geojson`, `geojsonp`, `rss`, `atom`
 `callback`           | JSONP or GEOJSONP callback
-`sort`               | Sorts results by the specified field (e.g. `record_timestamp`). By default, the sort is descending. A minus sign `-` may be used to perform an ascending sort. Sorting is only available on numeric fields (Integer, Decimal), date fields (Date, DateTime) and on text fields which have the sortable annotation
-`rows`               | Number of results to return in a single call. By default, `10` results are returned. While you can request for up to `10 000` results in a row, such requests are not optimal and can be throttled so you should consider splitting them into smaller ones or use the Records Download API. Note also that the cumulated value of the parameters `start` and `rows` cannot go over `10 000`. It means that with the Records Search API, there's no way to access a result with a position greater than `10 000`. If however you need to do so, consider again using the Records Download API.
+`sort`               | Sorts results by the specified field (for example, `record_timestamp`). By default, the sort is descending. A minus sign `-` may be used to perform an ascending sort. Sorting is only available on numeric fields (Integer, Decimal), date fields (Date, DateTime), and on text fields that have the sortable annotation
+`rows`               | Number of results to return in a single call. By default, `10` results are returned. While you can request up to `10 000` results in a row, such requests are not optimal and can be throttled. So, you should consider splitting them into smaller ones or use the Records Download API. Note also that the cumulated value of the parameters `start` and `rows` cannot go over `10 000`. It means that with the Records Search API, there's no way to access a result with a position greater than `10 000`. If you need to do so, consider again using the Records Download API.
 `start`              | Index of the first result to return (starting at 0). Use in conjunction with "rows" to implement paging
 
 ## Record Lookup API
@@ -95,7 +95,7 @@ GET /api/records/1.0/analyze HTTP/1.1
 
 This API provides powerful analytics features over a set of selected records.
 
-It returns analyzed results in light and easy to parse format which can used as an input of modern charting libraries such as **Highchart.js** or **D3.js**.
+It returns analyzed results in light and easy to parse format, which can be used as an input of modern charting libraries such as **Highchart.js** or **D3.js**.
 
 ### Parameters
 
@@ -166,7 +166,7 @@ Parameter            | Description
 `exclude.<FACET>`    | Exclude records where `FACET` has the specified value from the result set. It can be used several times for the same facet or for different facets
 `pretty_print`       | If set to true (default is false), pretty prints JSON and JSONP output
 `format`             | Format of the response output. Can be `json` (default), `jsonp`, `csv`
-`csv_separator`      | If the `format` is `csv`, defines the delimiter used. Can be `;` (default), `,`, <code>&#124;</code>, or any ASCII character. Special characters however may require URL encoding.
+`csv_separator`      | If the `format` is `csv`, defines the delimiter used. Can be `;` (default), `,`, <code>&#124;</code>, or any ASCII character. Special characters may require URL encoding.
 `callback`           | JSONP callback (only in JSONP requests)
 
 #### Aggregation parameters
@@ -202,13 +202,13 @@ https://documentation-resources.opendatasoft.com/api/records/1.0/analyze/?datase
 Parameter            | Description
 -------------------- | -----------
 `x`                  | Field on which the data aggregation will be based. This parameter is mandatory. It allows for analyzing a subset of data according to the different values of the fields. The behavior may vary according to the field type. For **Date** and **DateTime** fields, the slices are built from the dates using the level of aggregation defined through the `precision`  and `periodic`  parameters. For other field types, the actual field values are used as x values
-`y.<SERIE>.func`     | The definition of the analysis aggregation function. Multiple series can be computed at once, simply name this parameter with an arbitrary serie name that you may reuse for specifying the associated aggregated expression. The list of available aggregation functions is: `COUNT` , `AVG` , `SUM` , `MIN` , `MAX` , `STDDEV` , `SUMSQUARES` . These functions return the result of their execution on the expression provided in y.<SERIE>.expr (or simply the number of records for the `COUNT`  function) for each value of x
-`y.<SERIE>.expr`     | Defines the value to be aggregated. This parameter is mandatory for every aggregation function but the `COUNT`  function. The <SERIES> parameter must have the same name as the one used for the required corresponding aggregation function. The parameter may contain the name of a numeric field in the Dataset (**Int** or **Double**), or a mathematical expression (see below to get more details on the expression language).
+`y.<SERIE>.func`     | The definition of the analysis aggregation function. Multiple series can be computed at once. Simply name this parameter with an arbitrary series name that you may reuse for specifying the associated aggregated expression. The list of available aggregation functions is: `COUNT` , `AVG` , `SUM` , `MIN` , `MAX` , `STDDEV` , `SUMSQUARES` . These functions return the result of their execution on the expression provided in y.<SERIE>.expr (or simply the number of records for the `COUNT`  function) for each value of x
+`y.<SERIE>.expr`     | Defines the value to be aggregated. This parameter is mandatory for every aggregation function but the `COUNT`  function. The <SERIES> parameter must have the same name as the one used for the required corresponding aggregation function. The parameter may contain the name of a numeric field in the Dataset (**Int** or **Double**) or a mathematical expression (see below to get more details on the expression language).
 `y.<SERIE>.cumulative` | This parameter accepts values `true`  and `false`  (default). If the parameter is set to true, the results of a series are recursively summed up (`serie(x) = serie(x) + serie(x-1)` )
-`maxpoints`            | Limits the maximum number of results returned in the serie. By default there is no limit
+`maxpoints`            | Limits the maximum number of results returned in the serie. By default, there is no limit.
 `periodic`             | Used only in cases in which x is of type **Date** or **DateTime**. It defines the level at which aggregation is done. Possible values are `year`  (default), `month` , `week` , `weekday` , `day` , `hour` , `minute` . This parameter will allow you, for instance, to compute aggregations on months across all years. For instance, with a value set to `weekday` , the output will be: `[{"x": {"weekday":0},"series1": 12}, {"x": {"weekday":1},"series1": 30}]` . When `weekday`  is used, the generated value range from 0 to 6 where 0 corresponds to Monday and 6 to Sunday
-`precision`            | Used only in cases in which X is of type **Date** or **DateTime**. It defines the precision of the aggregation. Possible values are `year` , `month` , `week` , `day`  (default), `hour` , `minute` . If `weekday`  is provided as a `periodic`  parameter, the `precision`  parameter is ignored. This parameter shall respect the `precision`  annotation of the field. If the field is annotated with a precision set to `day` , the serie precision can at maximum be set to `day`
-`sort`                 | Sorts the aggregation values according to the specified series, or to the x parameter. By default, the values are sorted in descending order, according to the x parameter. A minus sign ('-') can however be prepended to the argument to make an ascending sort
+`precision`            | Used only in cases in which X is of type **Date** or **DateTime**. It defines the precision of the aggregation. Possible values are `year` , `month` , `week` , `day`  (default), `hour` , `minute` . If `weekday`  is provided as a `periodic`  parameter, the `precision`  parameter is ignored. This parameter shall respect the `precision`  annotation of the field. If the field is annotated with a precision set to `day` , the series precision can at maximum be set to `day`.
+`sort`                 | Sorts the aggregation values according to the specified series or to the x parameter. By default, the values are sorted in descending order, according to the x parameter. A minus sign ('-') can be prepended to the argument to make an ascending sort
 
 ### Expression language
 
@@ -253,7 +253,7 @@ GET /api/records/1.0/download HTTP/1.1
 ```
 
 This API provides an efficient way to download a large set of records out of a dataset. The HTTP
-answer is streamed which makes it possible to optimize the memory consumption client side.
+answer is streamed, which makes it possible to optimize the memory consumption client side.
 
 ### Parameters
 
@@ -269,7 +269,7 @@ Parameter            | Description
 `fields`             | Restricts field to retrieve. This parameter accepts multiple field names separated by commas. Example: `fields=field1,field2,field3`
 `pretty_print`       | If set to true (default is false), pretty prints JSON and JSONP output
 `format`             | Format of the response output. Can be `csv` (default), `json`, `jsonp`, `geojson`, `geojsonp`
-`csv_separator`      | If the `format` is `csv`, defines the delimiter used. Can be `;` (default), `,`, <code>&#124;</code>, or any ASCII character. Special characters however may require URL encoding.
+`csv_separator`      | If the `format` is `csv`, defines the delimiter used. Can be `;` (default), `,`, <code>&#124;</code>, or any ASCII character. Special characters may require URL encoding.
 `callback`           | JSONP or GEOJSONP callback
 
 ## Records Geo Clustering API
@@ -394,4 +394,4 @@ Parameter            | Description
 `clusterprecision`   | The desired precision level, depending on the current map zoom level (for example, the Leaflet zoom level). This parameter is mandatory
 `shapeprecision`     | The precision of the returned cluster envelope. The sum of clusterprecision and shapeprecision must not exceed 29
 `clustermode`        | The desired clustering mode. Supported values are `polygon` (default) and `heatmap`
-`y.<SERIE>.func`, `y.<SERIE>.expr` | This API also accepts a serie definition as described in the record analysis API. If a serie is defined, the aggregation will be performed using the values of the serie
+`y.<SERIE>.func`, `y.<SERIE>.expr` | This API also accepts a series definition as described in the record analysis API. If a serie is defined, the aggregation will be performed using the values of the series.

--- a/source/includes/v1/records_api.md
+++ b/source/includes/v1/records_api.md
@@ -35,10 +35,44 @@ Parameter            | Description
 GET /api/datasets/1.0/<dataset_id>/records/<record_id> HTTP/1.1
 ```
 
-> Example lookup for record `ff1f5b718ce2ee87f18dfaf20610f257979f2f4a` in dataset `world-heritage-unesco-list`:
+> Example lookup for the record `d087227c3595eb1e5b7d09dacfdfd6cafb86562a` in the dataset `doc-geonames-cities-5000`:
 
 ```text
-https://examples.opendatasoft.com/api/datasets/1.0/world-heritage-unesco-list/records/ff1f5b718ce2ee87f18dfaf20610f257979f2f4a
+https://documentation-resources.opendatasoft.com/api/datasets/1.0/doc-geonames-cities-5000/records/d087227c3595eb1e5b7d09dacfdfd6cafb86562a
+```
+
+```json
+{
+    "datasetid": "doc-geonames-cities-5000",
+    "recordid": "d087227c3595eb1e5b7d09dacfdfd6cafb86562a",
+    "fields": {
+        "name": "Paris",
+        "modification_date": "2020-05-26",
+        "geonameid": "2988507",
+        "feature_class": "P",
+        "admin2_code": "75",
+        "geo_point_2d": [
+            48.85341,
+            2.3488
+        ],
+        "timezone": "Europe/Paris",
+        "feature_code": "PPLC",
+        "dem": 42,
+        "country_code": "FR",
+        "admin1_code": "11",
+        "alternatenames": "Baariis,Bahliz,Ile-de-France,Lungsod ng Paris,Lutece,Lutetia,Lutetia Parisorum,Lutèce,PAR,Pa-ri,Paarys,Palika,Paname,Pantruche,Paraeis,Paras,Pari,Paries,Parigge,Pariggi,Parighji,Parigi,Pariis,Pariisi,Pariizu,Pariižu,Parij,Parijs,Paris,Parisi,Parixe,Pariz,Parize,Parizh,Parizh osh,Parizh',Parizo,Parizs,Pariž,Parys,Paryz,Paryzh,Paryzius,Paryż,Paryžius,Paräis,París,Paríž,Parîs,Parĩ,Parī,Parīze,Paříž,Páras,Párizs,Ville-Lumiere,Ville-Lumière,ba li,barys,pairisa,pali,pari,paris,parys,paryzh,perisa,pryz,pyaris,pyarisa,pyrs,Île-de-France,Παρίσι,Париж,Париж ош,Парижь,Париз,Парис,Парыж,Паріж,Փարիզ,פאריז,פריז,باريس,پارىژ,پاريس,پاریس,پیرس,ܦܐܪܝܣ,पॅरिस,पेरिस,पैरिस,প্যারিস,ਪੈਰਿਸ,પૅરિસ,பாரிஸ்,పారిస్,ಪ್ಯಾರಿಸ್,പാരിസ്,ปารีส,ཕ་རི།,ပါရီမြို့,პარიზი,ፓሪስ,ប៉ារីស,パリ,巴黎,파리",
+        "asciiname": "Paris",
+        "population": 2138551
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            2.3488,
+            48.85341
+        ]
+    },
+    "record_timestamp": "2021-01-04T11:22:14.440000+00:00"
+}
 ```
 
 This API makes it possible to fetch an individual record using its identifier (Record ID).
@@ -67,20 +101,57 @@ It returns analyzed results in light and easy to parse format which can used as 
 
 #### Filtering parameters
 
-> Count World Heritage Unesco sites in each category, filtered by a polygon in Central Europe:
+> Count cities with a population greater than 5,000 inhabitants in each country code, filtered by a polygon in Central Europe:
 
 ```text
-https://examples.opendatasoft.com/api/records/1.0/analyze/?dataset=world-heritage-unesco-list&x=category&y.my_count.func=COUNT&geofilter.polygon=(50.0,0.0),(50.0,10.0),(40.0,10.0),(40.0,0.0)
+https://documentation-resources.opendatasoft.com/api/records/1.0/analyze/?dataset=doc-geonames-cities-5000&x=country_code&y.my_count.func=COUNT&geofilter.polygon=(50.0,0.0),(50.0,10.0),(40.0,10.0),(40.0,0.0)
 ```
 
 ```json
-[{
-        "x": "Cultural",
-        "my_count": 59
+[
+    {
+        "x": "AD",
+        "my_count": 7
     },
     {
-        "x": "Natural",
-        "my_count": 5
+        "x": "AT",
+        "my_count": 16
+    },
+    {
+        "x": "BE",
+        "my_count": 13
+    },
+    {
+        "x": "CH",
+        "my_count": 342
+    },
+    {
+        "x": "DE",
+        "my_count": 677
+    },
+    {
+        "x": "ES",
+        "my_count": 261
+    },
+    {
+        "x": "FR",
+        "my_count": 1468
+    },
+    {
+        "x": "IT",
+        "my_count": 512
+    },
+    {
+        "x": "LI",
+        "my_count": 11
+    },
+    {
+        "x": "LU",
+        "my_count": 17
+    },
+    {
+        "x": "MC",
+        "my_count": 3
     }
 ]
 ```
@@ -100,58 +171,30 @@ Parameter            | Description
 
 #### Aggregation parameters
 
-> Return the area in hectares of the biggest World Heritage Unesco site in each country:
+> Return the population size of the biggest city for each country code:
 
 ```text
-https://examples.opendatasoft.com/api/records/1.0/analyze/?dataset=world-heritage-unesco-list&x=country_en&y.max_area.func=MAX&y.max_area.expr=area_hectares
+https://documentation-resources.opendatasoft.com/api/records/1.0/analyze/?dataset=doc-geonames-cities-5000&x=country_code&y.max_population.func=MAX&y.max_population.expr=population
 ```
 
 ```json
-[{
-        "x": "Afghanistan",
-        "max_area": 158.9265
+[
+    {
+        "x": "AD",
+        "max_population": 20430
     },
     {
-        "x": "Albania",
-        "max_area": 58.9
-    },
-    {
-        "x": "Algeria",
-        "max_area": 665.03
+        "x": "AE",
+        "max_population": 2956587
     },
     /* ... */
     {
-        "x": "Zimbabwe",
-        "max_area": 676600
+        "x": "ZM",
+        "max_population": 1267440
     },
     {
-        "x": "the Former Yugoslav Republic of Macedonia",
-        "max_area": 83350
-    }
-]
-```
-
-> Return the count of sites inscribed each month and year:
-
-```text
-https://examples.opendatasoft.com/api/records/1.0/analyze/?dataset=world-heritage-unesco-list&x=date_inscribed&periodic=year&precision=month&y.another_count.func=COUNT
-```
-
-```json
-[{
-        "x": {
-            "month": 1,
-            "year": 1978
-        },
-        "another_count": 12
-    },
-    /* ... */
-    {
-        "x": {
-            "month": 1,
-            "year": 1980
-        },
-        "another_count": 27
+        "x": "ZW",
+        "max_population": 1542813
     }
 ]
 ```
@@ -169,24 +212,30 @@ Parameter            | Description
 
 ### Expression language
 
-> Return the average value of twice the sinus of the areas for each category (for the sake of example):
+> Return the average value of twice the square root of the population for each country code (for the sake of example):
 
 ``` text
-https://examples.opendatasoft.com/api/records/1.0/analyze/?dataset=world-heritage-unesco-list&x=category&y.series1.func=AVG&y.series1.expr=sin(area_hectares)*2
+https://documentation-resources.opendatasoft.com/api/records/1.0/analyze/?dataset=doc-geonames-cities-5000&x=country_code&y.series1.func=AVG&y.series1.expr=sqrt(population)*2
 ```
 
 ```json
-[{
-        "x": "Cultural",
-        "series1": 0.06208366995525825
+[
+    {
+        "x": "AD",
+        "series1": 189.14616030045894
     },
     {
-        "x": "Mixed",
-        "series1": 0.47869568886889907
+        "x": "AE",
+        "series1": 849.7322922436006
+    },
+    /* ... */
+    {
+        "x": "ZM",
+        "series1": 389.98380339301144
     },
     {
-        "x": "Natural",
-        "series1": 0.018136045219311035
+        "x": "ZW",
+        "series1": 438.7610954217565
     }
 ]
 ```
@@ -256,54 +305,84 @@ Parameter            | Description
 
 ### Clustering parameters
 
-> Return clusters and shapes with low precision and the average area in each cluster
+> Return clusters and shapes with low precision and the average population in each cluster
 
 ```text
-https://examples.opendatasoft.com/api/records/1.0/geocluster/?dataset=world-heritage-unesco-list&shapeprecision=1&clusterprecision=3&y.avg_area.func=AVG&y.avg_area.expr=area_hectares```
+https://documentation-resources.opendatasoft.com/api/records/1.0/geocluster/?dataset=doc-geonames-cities-5000&shapeprecision=1&clusterprecision=3&clusterdistance=50&y.avg_population.func=AVG&y.avg_population.expr=population
 ```
 
 ```json
 {
-    "clusters": [{
-            "cluster_center": [
-                10.523538180927272, -60.95864515091818
-            ],
-            "cluster": {
-                "type": "Polygon",
-                "coordinates": [
-                    [[-62.00833333, -2.333333333],[-66.89068,10.49073],[-66.125,18.46666667],[-61.7616666667,17.0069444444],[-55.15,5.82611],[-56.5,4],[-62.00833333, -2.333333333]]
-                ]
-            },
-            "count": 11,
-            "series": {
-                "avg_area": 917952.2154545453
-            }
-        },
+    "clusters": [
         /* ... */
         {
             "cluster_center": [
-                49.942863890000005, -55.08576666776667
+                64.73423996474594,
+                177.51029999926686
             ],
+            "count": 1,
+            "series": {
+                "avg_population": 10332
+            },
+            "cluster": {
+                "type": "Point",
+                "coordinates": [
+                    177.51029999926686,
+                    64.73423996474594
+                ]
+            }
+        },
+        {
+            "cluster_center": [
+                54.03621598239988,
+                158.9805759564042
+            ],
+            "count": 5,
+            "series": {
+                "avg_population": 54285.8
+            },
             "cluster": {
                 "type": "Polygon",
                 "coordinates": [
-                    [[-53.2111111111, 46.635],[-56.4295222222, 51.726925],[-55.61666667, 51.46666667],[-53.2111111111, 46.635]]
+                    [
+                        [
+                            158.40468998998404,
+                            52.93109998572618
+                        ],
+                        [
+                            158.38134999386966,
+                            53.18908997811377
+                        ],
+                        [
+                            158.6206699255854,
+                            54.69609996769577
+                        ],
+                        [
+                            160.84540992043912,
+                            56.32034998387098
+                        ],
+                        [
+                            158.65075995214283,
+                            53.0444399965927
+                        ],
+                        [
+                            158.40468998998404,
+                            52.93109998572618
+                        ]
+                    ]
                 ]
-            },
-            "count": 3,
-            "series": {
-                "avg_area": 2838.3243333333335
             }
-        }
+        },
+        /* ... */
     ],
     "count": {
-        "max": 137,
+        "max": 5473,
         "min": 1
     },
     "series": {
-        "avg_area": {
-            "max": 40825000,
-            "min": 0
+        "avg_population": {
+            "max": 645386.6153846154,
+            "min": 2
         }
     },
     "clusterprecision": 3

--- a/source/includes/v1/records_api.md
+++ b/source/includes/v1/records_api.md
@@ -393,5 +393,6 @@ Parameter            | Description
 -------------------- | -----------
 `clusterprecision`   | The desired precision level, depending on the current map zoom level (for example, the Leaflet zoom level). This parameter is mandatory
 `shapeprecision`     | The precision of the returned cluster envelope. The sum of clusterprecision and shapeprecision must not exceed 29
+`clusterdistance`   | The distance from the cluster center (the radius). This parameter is mandatory
 `clustermode`        | The desired clustering mode. Supported values are `polygon` (default) and `heatmap`
 `y.<SERIE>.func`, `y.<SERIE>.expr` | This API also accepts a series definition as described in the record analysis API. If a serie is defined, the aggregation will be performed using the values of the series.

--- a/source/includes/v1/using_facets.md
+++ b/source/includes/v1/using_facets.md
@@ -3,7 +3,7 @@
 A facet can be considered as a valued tag associated with a record. For instance, let's say a dataset has a facet
 "City". A record in this dataset could have the value "Paris" for the "City" facet.
 
-Facets are for instance used for building the left navigation column, both for dataset catalog exploration page and
+Facets are, for instance, used for building the left navigation column, both for dataset catalog exploration page and
 dataset records exploration page.
 
 Facets are especially useful to implement guided navigation in large result sets.
@@ -54,8 +54,8 @@ Facet Name           | Description
 }
 ```
 
-In the records API, facets are defined at field level. A field facet can be available depending on the data producer
-choices. Fields (retrieved for instance from the Dataset Lookup API) for which faceting is available can be easily
+In the records API, facets are defined at the field level. A field facet can be available depending on the data producer
+choices. Fields (retrieved, for instance, from the Dataset Lookup API) for which faceting is available can be easily
 identified as shown in the example on the right.
 
 When faceting is enabled, facets are returned in the response after the result set.
@@ -95,7 +95,7 @@ the query context.
 ]
 ```
 
-Facets are hierarchical, for instance, a year facet will contain months facets and a month facet will contain days
+Facets are hierarchical. For instance, a year facet will contain months facets, and a month facet will contain days
 facets.
 
 > Example of a facet with all its attributes

--- a/source/includes/v1/using_facets.md
+++ b/source/includes/v1/using_facets.md
@@ -170,9 +170,9 @@ the state attribute are:
 It is possible to limit the result set by refining on a given facet value. To do so, use the following API parameter:
 `refine.FACETNAME=FACETVALUE`.
 
-For example: <https://public.opendatasoft.com/api/datasets/1.0/search?refine.modified=2013>.
+For example: <https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?refine.modified=2020>.
 
-In the returned result set, only the datasets modified in 2013 will be returned.
+In the returned result set, only the datasets modified in 2020 will be returned.
 
 As the refinement occurs on the "year" and as the "modified" facet is hierarchical, the sub-level is returned. Results
 are dispatched in the "month" sub value.
@@ -182,16 +182,16 @@ are dispatched in the "month" sub value.
 Using the same principle as above, it is possible to exclude from the result set the hits matching a given value of a
 given facet. To do so, use the following API parameter: `exclude.FACETNAME=FACETVALUE`.
 
-For example: <https://public.opendatasoft.com/api/datasets/1.0/search?exclude.modified=2013>
+For example: <https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?exclude.modified=2020>
 
-Only results that have not been modified in 2013 will be returned.
+Only results that have not been modified in 2020 will be returned.
 
 ## Disjunctive faceting
 
 By default, faceting is conjunctive. This means that the following context will lead down to no results:
-<https://public.opendatasoft.com/api/datasets/1.0/search?refine.modified=2013&refine.modified=2014>.
+<https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?refine.modified=2020&refine.modified=2021>.
 
 You can enable disjunctive faceting using the following API parameter: `disjunctive.FACETNAME=true`.
 
 For example:
-<https://public.opendatasoft.com/api/datasets/1.0/search?refine.modified=2013&refine.modified=2014&disjunctive.modified=true>
+<https://documentation-resources.opendatasoft.com/api/datasets/1.0/search?refine.modified=2020&refine.modified=2021&disjunctive.modified=true>


### PR DESCRIPTION
## Summary

This PR updates all examples based on different domains to examples based on the `documentation-resources` domain.

Story details: https://app.clubhouse.io/opendatasoft/story/26016

## Changes

- Updated examples in Search API v1 docs with paths and datasets from `documentation-resources`. The UNESCO dataset could not be used anymore, [Geonames Cities with population > 5000](https://documentation-resources.opendatasoft.com/explore/dataset/doc-geonames-cities-5000/table/) is now used to show request and response examples.
- Added [`clusterdistance`](https://github.com/opendatasoft/ods-documentation-explore-api/pull/78/files#diff-fc90698516242a65476b3197f1361625cdbf6b0e13e36f96433612dd64fe3076R396) to the mandatory clustering parameters.
- Fixed typos and grammar issues.