### PR TITLE
Update the examples in the OData API docs

### DIFF
--- a/source/includes/odata/odata_basics.md
+++ b/source/includes/odata/odata_basics.md
@@ -10,7 +10,7 @@ hostname. Unless stated otherwise, all addresses in the rest of this documentati
 
 ### HTTP Method
 
-The Opendatasoft OData service currently is read only, hence the only allowed method is GET.
+The Opendatasoft OData service currently is read-only; hence the only allowed method is GET.
 
 ## Versions
 
@@ -26,9 +26,7 @@ Header | Description
 **OData-MaxVersion** | This header specifies the maximum version supported by the client.
 **maxDataServiceVersion** | This header specifies the maximum version the service should use.
 
-From the next paragraph on, in order to keep things simple and relevant, all examples will illustrate protocol version
-4.0. Keep in mind however that all described features work in both supported version. If version 3.0 use a specific
-syntax or needs special attention, it shall be described.
+From the next paragraph on, in order to keep things simple and relevant, all the examples in this documentation use the OData protocol version 4.0. Keep in mind however that all described features work in both supported versions. If version 3.0 uses a specific syntax or needs special attention, it will be described in the documentation.
 
 ## Metadata
 
@@ -576,18 +574,17 @@ GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-citi
 50335
 ```
 
-There are 2 ways of obtaining the number of records in a dataset.
+There are 2 ways of obtaining the number of records in a dataset:
 
-- use the `$count` query parameter (`$inlinecount` for protocol version 3.0).
+- Using the `$count` query parameter (`$inlinecount` for protocol version 3.0)
 
-- navigate to the count document for a resource. This is achieved by querying `/<dataset_id>/$count`.
+- Navigating to the count document for a resource. This is achieved by querying `/<dataset_id>/$count`
 
 These two methods have slightly different semantics:
 
-- the first one returns the count relative to the payload, taking all operations into account, except for paging and is
-returned along with the payload,
-- the second one returns the absolute resource count, irrespective of anything
-other than the number of records present on the server and only returns the number, without any other information
+- The first one returns the count relative to the payload, taking all operations into account, except for paging, and is returned along with the payload.
+- The second one returns the absolute resource count, irrespective of anything
+other than the number of records present on the server, and only returns the number without any other information.
 
 ## Sort
 
@@ -599,7 +596,7 @@ GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-citi
 
 ```json
 {
-    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000(name,population,recordid)",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
     "value": [
         {
             "recordid": "e4b10f40f0dd992afc44e7cac52ede6b39f83bf5",
@@ -636,7 +633,7 @@ GET hhttps://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cit
 
 ```json
 {
-    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000(name,population,recordid)",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
     "value": [
         {
             "recordid": "c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8",
@@ -704,11 +701,11 @@ GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-citi
 }
 ```
 
-To access a specific record, its record id surrounded by parenthesis, can be appended to the dataset address.
+To access a specific record, append its record id surrounded by parentheses to the dataset address.
 
 ## Projection
 
-> Get all records that contain "Turin" in any of their fields and select only their `name`and `population` properties using projection
+> Get all records that contain "Turin" in any of their fields and select only their `name` and `population` properties using projection
 
 ```text
 GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$search=Turin&$select=name, population
@@ -744,6 +741,6 @@ GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-citi
 
 Results can be projected over specific fields using the `$select` parameter.
 
-For multiple fields to be subject of the projection, their names must be separated by a comma and an optional space.
+For fields to be included in a projection, their names must be separated by a comma and an optional space.
 
 This parameter can be used with datasets and specific records.

--- a/source/includes/odata/odata_basics.md
+++ b/source/includes/odata/odata_basics.md
@@ -628,7 +628,7 @@ GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-citi
 > Get all records that contain "Turin" in any of their fields and order records by population size in descending order
 
 ```text
-GET hhttps://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$search=Turin&$orderby=population desc
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$search=Turin&$orderby=population desc
 ```
 
 ```json
@@ -701,7 +701,7 @@ GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-citi
 }
 ```
 
-To access a specific record, append its record id surrounded by parentheses to the dataset address.
+To access a specific record, append its recordid surrounded by parentheses to the dataset address.
 
 ## Projection
 

--- a/source/includes/odata/odata_basics.md
+++ b/source/includes/odata/odata_basics.md
@@ -33,61 +33,61 @@ syntax or needs special attention, it shall be described.
 ## Metadata
 
 ```http
-GET https://examples.opendatasoft.com/api/odata/$metadata HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/$metadata HTTP/1.1
 ```
 
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
-  <edmx:DataServices xmlns:m="http://docs.oasis-open.org/odata/ns/metadata" m:MaxDataServiceVersion="4.0" m:DataServiceVersion="4.0">
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Alias="Ods" Namespace="com.opendatasoft.odata.types">
-      <ComplexType Name="GeoPoint2D">
-        <Property Type="Edm.Double" Name="latitude" />
-        <Property Type="Edm.Double" Name="longitude" />
-      </ComplexType>
-      <ComplexType Name="Image">
-        <Property Type="Edm.Int32" Name="width" />
-        <Property Type="Edm.String" Name="format" />
-        <Property Type="Edm.String" Name="id" />
-        <Property Type="Edm.Int32" Name="height" />
-      </ComplexType>
-    </Schema>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="examples.world-heritage-unesco-list">
-      <EntityType Name="world-heritage-unesco-list">
+    <edmx:DataServices xmlns:m="http://docs.oasis-open.org/odata/ns/metadata" m:MaxDataServiceVersion="4.0" m:DataServiceVersion="4.0">
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Alias="Ods" Namespace="com.opendatasoft.odata.types">
+            <ComplexType Name="GeoPoint2D">
+                <Property Type="Edm.Double" Name="latitude"/>
+                <Property Type="Edm.Double" Name="longitude"/>
+            </ComplexType>
+            <ComplexType Name="Image">
+                <Property Type="Edm.Int32" Name="width"/>
+                <Property Type="Edm.String" Name="format"/>
+                <Property Type="Edm.String" Name="id"/>
+                <Property Type="Edm.Int32" Name="height"/>
+            </ComplexType>
+        </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="documentation-resources.roman-emperor-images">
+            <EntityType Name="roman-emperor-images">
+                <Key>
+                    <PropertyRef Name="recordid"/>
+                </Key>
+                <Property Type="Edm.String" Name="recordid" Nullable="false"/>
+                <Property Type="Edm.String" Name="name"/>
+                <Property Type="Edm.String" Name="image"/>
+            </EntityType>
+        </Schema>
+        <!-- ... -->
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="documentation-resources.doc-geonames-cities-5000">
+    <EntityType Name="doc-geonames-cities-5000">
         <Key>
-          <PropertyRef Name="recordid" />
+            <PropertyRef Name="recordid"/>
         </Key>
-        <Property Type="Edm.String" Name="recordid" Nullable="false" />
-        <Property Type="Edm.String" Name="name_en" />
-        <Property Type="Edm.String" Name="name_fr" />
-        <Property Type="Edm.String" Name="short_description_en" />
-        <Property Type="Edm.String" Name="short_description_fr" />
-        <Property Type="Edm.String" Name="justification_en" />
-        <Property Type="Edm.String" Name="justification_fr" />
-        <Property Type="Edm.DateTimeOffset" Name="date_inscribed" />
-        <Property Type="Edm.String" Name="danger_list" />
-        <Property Type="Edm.Double" Name="longitude" />
-        <Property Type="Edm.Double" Name="latitude" />
-        <Property Type="Edm.Double" Name="area_hectares" />
-        <Property Type="Edm.String" Name="category" />
-        <Property Type="Edm.String" Name="country_en" />
-        <Property Type="Edm.String" Name="country_fr" />
-        <Property Type="Edm.String" Name="continent_en" />
-        <Property Type="Edm.String" Name="continent_fr" />
-        <Property Type="com.opendatasoft.odata.types.GeoPoint2D" Name="geographical_coordinates" />
-      </EntityType>
-    </Schema>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="examples.datasets">
-      <EntityContainer m:IsDefaultEntityContainer="true" Name="examplesContainer">
-        <EntitySet EntityType="examples.world-heritage-unesco-list.world-heritage-unesco-list" Name="world-heritage-unesco-list" />
-      </EntityContainer>
-      <Annotations Target="examples.world-heritage-unesco-list.world-heritage-unesco-list">
-        <Annotation Term="Org.OData.Publication.V1.PublisherName" String="UNESCO" />
-        <Annotation Term="Org.OData.Publication.V1.LastModified" String="2017-10-17T15:34:38+00:00" />
-        <Annotation Term="Org.OData.Publication.V1.Keywords" String="unesco, world" />
-        <Annotation Term="Org.OData.Display.V1.DisplayName" String="World Heritage - UNESCO List" />
-      </Annotations>
-    </Schema>
+        <Property Type="Edm.String" Name="recordid" Nullable="false"/>
+        <Property Type="Edm.String" Name="geonameid"/>
+        <Property Type="Edm.String" Name="name"/>
+        <Property Type="Edm.String" Name="asciiname"/>
+        <Property Type="Edm.String" Name="alternatenames"/>
+        <Property Type="Edm.String" Name="feature_class"/>
+        <Property Type="Edm.String" Name="feature_code"/>
+        <Property Type="Edm.String" Name="country_code"/>
+        <Property Type="Edm.String" Name="cc2"/>
+        <Property Type="Edm.String" Name="admin1_code"/>
+        <Property Type="Edm.String" Name="admin2_code"/>
+        <Property Type="Edm.String" Name="admin3_code"/>
+        <Property Type="Edm.String" Name="admin4_code"/>
+        <Property Type="Edm.Int32" Name="population"/>
+        <Property Type="Edm.String" Name="elevation"/>
+        <Property Type="Edm.Int32" Name="dem"/>
+        <Property Type="Edm.String" Name="timezone"/>
+        <Property Type="Edm.DateTimeOffset" Name="modification_date"/>
+        <Property Type="com.opendatasoft.odata.types.GeoPoint2D" Name="geo_point_2d"/>
+    </EntityType>
+</Schema>
   </edmx:DataServices>
 </edmx:Edmx>
 ```
@@ -102,7 +102,7 @@ The metadata document is located on `/$metadata`. This documents determines:
 ## Formats
 
 ```http
-GET https://examples.opendatasoft.com/api/odata/error?$format=json HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/error?$format=json HTTP/1.1
 ```
 
 ```json
@@ -115,7 +115,7 @@ GET https://examples.opendatasoft.com/api/odata/error?$format=json HTTP/1.1
 ```
 
 ```http
-GET https://examples.opendatasoft.com/api/odata/error?$format=xml HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/error?$format=xml HTTP/1.1
 ```
 
 ```xml
@@ -145,15 +145,17 @@ keep in mind that everything will work the same in the ATOM format.
 ## Catalog
 
 ```http
-GET https://examples.opendatasoft.com/api/odata/?$format=json HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/?$format=json HTTP/1.1
 ```
 
 ```json
 {
-"@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata",
-"value": [{
-        "name": "world-heritage-unesco-list",
-        "url": "world-heritage-unesco-list"
+"@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata",
+"value": [
+    /* ... */
+    {
+        "name": "doc-geonames-cities-5000",
+        "url": "doc-geonames-cities-5000"
     },
     /* ... */
     ]
@@ -165,37 +167,37 @@ The service root document displays the catalog of all datasets available through
 ## Datasets
 
 ```http
-GET https://examples.opendatasoft.com/api/odata/world-heritage-unesco-list HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000 HTTP/1.1
 ```
 
 ```json
 {
-{
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#world-heritage-unesco-list",
-    "value": [{
-            "recordid": "ff1f5b718ce2ee87f18dfaf20610f257979f2f4a",
-            "category": "Cultural",
-            "short_description_en": "The Architectural, Residential and Cultural Complex of the Radziwill Family at Nesvizh is located in central Belarus. [...]",
-            "name_fr": "Ensemble architectural, résidentiel et culturel de la famille Radziwill à Nesvizh",
-            "continent_en": "Europe and North America",
-            "justification_fr": "[...]",
-            "country_en": "Belarus",
-            "longitude": 26.69139,
-            "justification_en": "[...]",
-            "date_inscribed": "2005-01-01",
-            "continent_fr": "Europe et Amérique du nord",
-            "area_hectares": 0,
-            "latitude": 53.22278,
-            "name_en": "Architectural, Residential and Cultural Complex of the Radziwill Family at Nesvizh",
-            "geographical_coordinates": {
-                "latitude": 53.22278,
-                "longitude": 26.69139
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
+    "value": [
+        /* ... */
+        {
+            "recordid": "a09667c806f6e64f81843ef3281973dd6d96dbc2",
+            "name": "Independencia",
+            "modification_date": "2014-04-11T00:00:00+00:00",
+            "geonameid": "8858196",
+            "feature_class": "P",
+            "admin2_code": "011",
+            "geo_point_2d": {
+            "latitude": 18.87716,
+            "longitude": -99.12237
             },
-            "country_fr": "Bélarus"
+            "timezone": "America/Mexico_City",
+            "feature_code": "PPL",
+            "dem": 1446,
+            "country_code": "MX",
+            "admin1_code": "17",
+            "alternatenames": "Independencia",
+            "asciiname": "Independencia",
+            "population": 7282
         },
         /* ... */
     ],
-    "@odata.nextLink": "https://examples.opendatasoft.com/api/odata/world-heritage-unesco-list?$skiptoken=100"
+    "@odata.nextLink": "https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$skiptoken=100"
 }
 }
 ```
@@ -205,62 +207,111 @@ document to a dataset by following the URL attribute of the catalog items.
 
 ## Paging
 
+> Get the top 2 results
 
 ```http
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$top=2 HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$top=2 HTTP/1.1
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
     "value": [
         {
-            "recordid": "6767d8330abd8b38d0207cef113dcb94e50ebfd6",
-            "gender": "F",
-            "state": "NC",
-            "number": 645,
-            "name": "Emma",
-            "year": "2013"
+            "recordid": "9a5943b0ace876e384142c032f6b229a9c77e1fe",
+            "name": "Marte R. Gómez (Tobarito)",
+            "modification_date": "2014-04-11T00:00:00+00:00",
+            "geonameid": "8858173",
+            "feature_class": "P",
+            "admin2_code": "018",
+            "geo_point_2d": {
+                "latitude": 27.36778,
+                "longitude": -109.88583
+            },
+            "timezone": "America/Hermosillo",
+            "feature_code": "PPL",
+            "dem": 49,
+            "country_code": "MX",
+            "admin1_code": "26",
+            "alternatenames": "Marte R. Gomez (Tobarito),Marte R. Gómez (Tobarito)",
+            "asciiname": "Marte R. Gomez (Tobarito)",
+            "population": 8700
         },
         {
-            "recordid": "c7faeb25c4bfeb820c4e80864c7861192508d0d2",
-            "gender": "F",
-            "state": "NC",
-            "number": 272,
-            "name": "Ella",
-            "year": "2013"
+            "recordid": "e2e9d83f86c4dddfeefd349be9fbdd67c7b8ce23",
+            "name": "Colonia Santa Bárbara",
+            "modification_date": "2014-08-18T00:00:00+00:00",
+            "geonameid": "8858175",
+            "feature_class": "P",
+            "admin2_code": "087",
+            "geo_point_2d": {
+                "latitude": 19.50191,
+                "longitude": -96.87817
+            },
+            "timezone": "America/Mexico_City",
+            "feature_code": "PPL",
+            "dem": 1277,
+            "country_code": "MX",
+            "admin1_code": "30",
+            "alternatenames": "Colonia Santa Barbara,Colonia Santa Bárbara",
+            "asciiname": "Colonia Santa Barbara",
+            "population": 8617
         }
-    ],
-    "@odata.nextLink": "https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$skiptoken=2"
+    ]
 }
 ```
 
+> Skip the top result and get the next two results
+
 ```http
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$skip=1&$top=2 HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$skip=1&$top=2 HTTP/1.1
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
     "value": [
         {
-            "recordid": "c7faeb25c4bfeb820c4e80864c7861192508d0d2",
-            "gender": "F",
-            "state": "NC",
-            "number": 272,
-            "name": "Ella",
-            "year": "2013"
+            "recordid": "e2e9d83f86c4dddfeefd349be9fbdd67c7b8ce23",
+            "name": "Colonia Santa Bárbara",
+            "modification_date": "2014-08-18T00:00:00+00:00",
+            "geonameid": "8858175",
+            "feature_class": "P",
+            "admin2_code": "087",
+            "geo_point_2d": {
+                "latitude": 19.50191,
+                "longitude": -96.87817
+            },
+            "timezone": "America/Mexico_City",
+            "feature_code": "PPL",
+            "dem": 1277,
+            "country_code": "MX",
+            "admin1_code": "30",
+            "alternatenames": "Colonia Santa Barbara,Colonia Santa Bárbara",
+            "asciiname": "Colonia Santa Barbara",
+            "population": 8617
         },
         {
-            "recordid": "d5fd82cf69691db575de6cfe207d105caa10f68c",
-            "gender": "F",
-            "state": "NC",
-            "number": 263,
-            "name": "Natalie",
-            "year": "2013"
+            "recordid": "dff5e7b1376eb0e983e3e823baa3d8ab11bc08e7",
+            "name": "Bosque de Saloya",
+            "modification_date": "2014-04-11T00:00:00+00:00",
+            "geonameid": "8858176",
+            "feature_class": "P",
+            "admin2_code": "013",
+            "geo_point_2d": {
+                "latitude": 18.01611,
+                "longitude": -92.95806
+            },
+            "timezone": "America/Mexico_City",
+            "feature_code": "PPL",
+            "dem": 8,
+            "country_code": "MX",
+            "admin1_code": "27",
+            "alternatenames": "Bosque de Saloya",
+            "asciiname": "Bosque de Saloya",
+            "population": 8600
         }
-    ],
-    "@odata.nextLink": "https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$skiptoken=3"
+    ]
 }
 ```
 
@@ -278,45 +329,95 @@ When paging is applied, a link to the next results will be added at the end of t
 
 ## Search
 
+> Get all records that contain "Turin" in any of their fields
+
 ```http
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$search=Cad HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$search=Turin HTTP/1.1
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
     "value": [
         {
-            "recordid": "d060a6452d427b6e56ec0ed12307bda1a65ade4d",
-            "gender": "F",
-            "state": "NC",
-            "number": 5,
-            "name": "Cadance",
-            "year": "2013"
+            "recordid": "c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8",
+            "elevation": "239",
+            "name": "Turin",
+            "modification_date": "2019-09-05T00:00:00+00:00",
+            "geonameid": "3165524",
+            "feature_class": "P",
+            "admin3_code": "001272",
+            "admin2_code": "TO",
+            "geo_point_2d": {
+                "latitude": 45.07049,
+                "longitude": 7.68682
+            },
+            "timezone": "Europe/Rome",
+            "feature_code": "PPLA",
+            "dem": 245,
+            "country_code": "IT",
+            "admin1_code": "12",
+            "alternatenames": "Augusta Taurinorum,Julia Augusta Taurinorum,Lungsod ng Turino,TRN,Tori,Torin,Torino,Torinu,Torí,Tueri,Turen,Turijn,Turim,Turin,Turina,Turinas,Turino,Turinu,Turyn,Turén,Turìn,Turín,Turīna,Tórínó,Türì,dou ling,tolino,torino,tu rin,tulin,turin,turina,twryn,twrynw,Τορίνο,Торино,Турин,Турын,Թուրին,טורין,טורינו,تورينو,تورین,टोरीनो,तोरिनो,তুরিন,துரின்,ตูริน,ཊུ་རིན།,ტურინი,トリノ,都灵,토리노,투린",
+            "asciiname": "Turin",
+            "admin4_code": "0012721",
+            "population": 870456
         },
         {
-            "recordid": "efc3e55da1dd591ba0c2bd42f0b0719e330f738f",
-            "gender": "M",
-            "state": "NC",
-            "number": 79,
-            "name": "Caden",
-            "year": "2013"
+            "recordid": "61eb5f69a96ba0c694a800f02802c0cc488aad91",
+            "name": "Turinskaya Sloboda",
+            "modification_date": "2019-09-02T00:00:00+00:00",
+            "geonameid": "1488931",
+            "feature_class": "P",
+            "geo_point_2d": {
+                "latitude": 57.6232,
+                "longitude": 64.38575
+            },
+            "timezone": "Asia/Yekaterinburg",
+            "feature_code": "PPL",
+            "dem": 64,
+            "country_code": "RU",
+            "admin1_code": "71",
+            "alternatenames": "Turinskaja Sloboda,Turinskaja-Sloboda,Turinskaya Sloboda,Туринская Слобода",
+            "asciiname": "Turinskaya Sloboda",
+            "population": 6023
         },
         {
-            "recordid": "025f3eb0e7443f7ab7809f06685a06064cade230",
-            "gender": "F",
-            "state": "NC",
-            "number": 41,
-            "name": "Cadence",
-            "year": "2013"
+            "recordid": "ef5d7d2506846f5581087d9070ff90e440056e86",
+            "name": "Turinsk",
+            "modification_date": "2019-09-05T00:00:00+00:00",
+            "geonameid": "1488933",
+            "feature_class": "P",
+            "geo_point_2d": {
+                "latitude": 58.04575,
+                "longitude": 63.69605
+            },
+            "timezone": "Asia/Yekaterinburg",
+            "feature_code": "PPL",
+            "dem": 100,
+            "country_code": "RU",
+            "admin1_code": "71",
+            "alternatenames": "Toerinsk,Tourinsk,Turins'k,Turinsk,Turynsk,tu lin si ke,twrynsk,Τουρίνσκ,Туринск,Туринськ,Турынск,Түре,تورينسك,تورینسک,圖林斯克",
+            "asciiname": "Turinsk",
+            "population": 18555
         },
         {
-            "recordid": "67eab51bfaf034d88b5a98819bef98961084e449",
-            "gender": "M",
-            "state": "NC",
-            "number": 30,
-            "name": "Cade",
-            "year": "2013"
+            "recordid": "e4b10f40f0dd992afc44e7cac52ede6b39f83bf5",
+            "name": "Tura",
+            "modification_date": "2012-12-02T00:00:00+00:00",
+            "geonameid": "2014833",
+            "feature_class": "P",
+            "geo_point_2d": {
+                "latitude": 64.27769,
+                "longitude": 100.21849
+            },
+            "timezone": "Asia/Krasnoyarsk",
+            "feature_code": "PPL",
+            "dem": 214,
+            "country_code": "RU",
+            "admin1_code": "91",
+            "alternatenames": "Toera,Toura,Tura,Turinskaya Kul'tbaza,Turinskaya Kul’tbaza,Turinskaya Kutbaza,tu la,tula,Тура,圖拉,투라",
+            "asciiname": "Tura",
+            "population": 5444
         }
     ]
 }
@@ -326,49 +427,95 @@ The `$search` parameter can be used to search data.
 
 ## Restriction
 
+> Get all cities named "Turin"
+
 ```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$filter=name eq Caden
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$filter=name eq Turin
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
     "value": [
         {
-            "recordid": "efc3e55da1dd591ba0c2bd42f0b0719e330f738f",
-            "gender": "M",
-            "state": "NC",
-            "number": 79,
-            "name": "Caden",
-            "year": "2013"
+            "recordid": "c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8",
+            "elevation": "239",
+            "name": "Turin",
+            "modification_date": "2019-09-05T00:00:00+00:00",
+            "geonameid": "3165524",
+            "feature_class": "P",
+            "admin3_code": "001272",
+            "admin2_code": "TO",
+            "geo_point_2d": {
+                "latitude": 45.07049,
+                "longitude": 7.68682
+            },
+            "timezone": "Europe/Rome",
+            "feature_code": "PPLA",
+            "dem": 245,
+            "country_code": "IT",
+            "admin1_code": "12",
+            "alternatenames": "Augusta Taurinorum,Julia Augusta Taurinorum,Lungsod ng Turino,TRN,Tori,Torin,Torino,Torinu,Torí,Tueri,Turen,Turijn,Turim,Turin,Turina,Turinas,Turino,Turinu,Turyn,Turén,Turìn,Turín,Turīna,Tórínó,Türì,dou ling,tolino,torino,tu rin,tulin,turin,turina,twryn,twrynw,Τορίνο,Торино,Турин,Турын,Թուրին,טורין,טורינו,تورينو,تورین,टोरीनो,तोरिनो,তুরিন,துரின்,ตูริน,ཊུ་རིན།,ტურინი,トリノ,都灵,토리노,투린",
+            "asciiname": "Turin",
+            "admin4_code": "0012721",
+            "population": 870456
         }
     ]
 }
 ```
 
+> Get all cities with a population between 100,000 and 100,050 inhabitants
+
 ```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$filter=number gt 280 and not number ge 285
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$filter=population gt 100000 and not population ge 100050
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
     "value": [
         {
-            "recordid": "5842808cd7f07f1e1ca733457605dfaadfcbc0a4",
-            "gender": "M",
-            "state": "NC",
-            "number": 282,
-            "name": "Isaac",
-            "year": "2013"
+            "recordid": "c8ed94ed7799ed2be371b705c210e3caced7003a",
+            "name": "Telde",
+            "modification_date": "2012-03-04T00:00:00+00:00",
+            "geonameid": "2510542",
+            "feature_class": "P",
+            "admin3_code": "35026",
+            "admin2_code": "GC",
+            "geo_point_2d": {
+                "latitude": 27.99243,
+                "longitude": -15.41915
+            },
+            "timezone": "Atlantic/Canary",
+            "feature_code": "PPLA3",
+            "dem": 160,
+            "country_code": "ES",
+            "admin1_code": "53",
+            "alternatenames": "Tel'de,Telde,te er de,tyldy,Телде,Тельде,تيلدي,特尔德",
+            "asciiname": "Telde",
+            "population": 100015
         },
         {
-            "recordid": "27676f39b6282bca2ab52e5e00468a269aabfbd0",
-            "gender": "M",
-            "state": "NC",
-            "number": 281,
-            "name": "Dylan",
-            "year": "2013"
+            "recordid": "668fa56460183a49c125bab9080a8dedba25fc87",
+            "name": "Punta Cana",
+            "modification_date": "2016-06-05T00:00:00+00:00",
+            "geonameid": "3494242",
+            "feature_class": "P",
+            "admin3_code": "110103",
+            "admin2_code": "1101",
+            "geo_point_2d": {
+                "latitude": 18.58182,
+                "longitude": -68.40431
+            },
+            "timezone": "America/Santo_Domingo",
+            "feature_code": "PPL",
+            "dem": 28,
+            "country_code": "DO",
+            "admin1_code": "10",
+            "alternatenames": "PUJ,Punta Cana,Punta Kana,Punta-Kana,Пунта Кана,Пунта-Кана",
+            "asciiname": "Punta Cana",
+            "admin4_code": "11010304",
+            "population": 100023
         }
     ]
 }
@@ -384,34 +531,49 @@ Expressions can be negated with the `not` operator.
 
 ## Count
 
+> Get the number of cities with a population of more than 3 million inhabitants and the top result
+
 ```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$filter=number lt 8&$top=1&$count=true
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$filter=population gt 3000000&$top=1&$count=true
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
-    "@odata.count": 966,
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000",
+    "@odata.count": 93,
     "value": [
         {
-            "recordid": "9acf1ee923cdd25b61027056d3bbde9bfa4681dd",
-            "gender": "F",
-            "state": "NC",
-            "number": 7,
-            "name": "Adah",
-            "year": "2013"
+            "recordid": "da3786f79d168b68547eb6c90fc7a8098f6f5461",
+            "name": "Ibadan",
+            "modification_date": "2019-09-05T00:00:00+00:00",
+            "geonameid": "2339354",
+            "feature_class": "P",
+            "admin2_code": "31008",
+            "geo_point_2d": {
+                "latitude": 7.37756,
+                "longitude": 3.90591
+            },
+            "timezone": "Africa/Lagos",
+            "feature_code": "PPLA",
+            "dem": 181,
+            "country_code": "NG",
+            "admin1_code": "32",
+            "alternatenames": "IBA,Ibadan,Ibadan shaary,Ibadana,Ibadanas,Ibadano,Ibadán,abadan,aybadan,ibadan,ibadana,yi ba dan,Ìbàdàn,İbadan,Ібадан,Ибадан,Ибадан шаары,איבדאן,إبادان,إيبادان,ابادان,ਇਬਾਦਾਨ,イバダン,伊巴丹,이바단",
+            "asciiname": "Ibadan",
+            "population": 3565108
         }
-    ],
-    "@odata.nextLink": "https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$skiptoken=1&$filter=number%20lt%208&$count=true"
+    ]
 }
 ```
 
+> Get the number of records in the `doc-geonames-cities-5000` dataset
+
 ```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013/$count
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000/$count
 ```
 
 ```text
-2841
+50335
 ```
 
 There are 2 ways of obtaining the number of records in a dataset.
@@ -429,89 +591,76 @@ other than the number of records present on the server and only returns the numb
 
 ## Sort
 
+> Get all records that contain "Turin" in any of their fields and order records by population size in ascending order
+
 ```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$search=Cad&$orderby=number
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$search=Turin&$orderby=population
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000(name,population,recordid)",
     "value": [
         {
-            "recordid": "d060a6452d427b6e56ec0ed12307bda1a65ade4d",
-            "gender": "F",
-            "state": "NC",
-            "number": 5,
-            "name": "Cadance",
-            "year": "2013"
+            "recordid": "e4b10f40f0dd992afc44e7cac52ede6b39f83bf5",
+            "name": "Tura",
+            /* ... */
+            "population": 5444
         },
         {
-            "recordid": "67eab51bfaf034d88b5a98819bef98961084e449",
-            "gender": "M",
-            "state": "NC",
-            "number": 30,
-            "name": "Cade",
-            "year": "2013"
+            "recordid": "61eb5f69a96ba0c694a800f02802c0cc488aad91",
+            "name": "Turinskaya Sloboda",
+            /* ... */
+            "population": 6023
         },
         {
-            "recordid": "025f3eb0e7443f7ab7809f06685a06064cade230",
-            "gender": "F",
-            "state": "NC",
-            "number": 41,
-            "name": "Cadence",
-            "year": "2013"
+            "recordid": "ef5d7d2506846f5581087d9070ff90e440056e86",
+            "name": "Turinsk",
+            /* ... */
+            "population": 18555
         },
         {
-            "recordid": "efc3e55da1dd591ba0c2bd42f0b0719e330f738f",
-            "gender": "M",
-            "state": "NC",
-            "number": 79,
-            "name": "Caden",
-            "year": "2013"
+            "recordid": "c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8",
+            "name": "Turin",
+            /* ... */
+            "population": 870456
         }
     ]
 }
 ```
+> Get all records that contain "Turin" in any of their fields and order records by population size in descending order
 
 ```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$search=Cad&$orderby=number desc
+GET hhttps://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$search=Turin&$orderby=population desc
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000(name,population,recordid)",
     "value": [
         {
-            "recordid": "efc3e55da1dd591ba0c2bd42f0b0719e330f738f",
-            "gender": "M",
-            "state": "NC",
-            "number": 79,
-            "name": "Caden",
-            "year": "2013"
+            "recordid": "c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8",
+            "name": "Turin",
+            /* ... */
+            "population": 870456
         },
         {
-            "recordid": "025f3eb0e7443f7ab7809f06685a06064cade230",
-            "gender": "F",
-            "state": "NC",
-            "number": 41,
-            "name": "Cadence",
-            "year": "2013"
+            "recordid": "ef5d7d2506846f5581087d9070ff90e440056e86",
+            "name": "Turinsk",
+            /* ... */
+            "population": 18555
         },
         {
-            "recordid": "67eab51bfaf034d88b5a98819bef98961084e449",
-            "gender": "M",
-            "state": "NC",
-            "number": 30,
-            "name": "Cade",
-            "year": "2013"
+            "recordid": "61eb5f69a96ba0c694a800f02802c0cc488aad91",
+            "name": "Turinskaya Sloboda",
+            /* ... */
+            "population": 6023
         },
         {
-            "recordid": "d060a6452d427b6e56ec0ed12307bda1a65ade4d",
-            "gender": "F",
-            "state": "NC",
-            "number": 5,
-            "name": "Cadance",
-            "year": "2013"
+            "recordid": "e4b10f40f0dd992afc44e7cac52ede6b39f83bf5",
+            "name": "Tura",
+            /* ... */
+            "population": 5444
         }
     ]
 }
@@ -522,19 +671,36 @@ followed by the `asc` and `desc` keywords to specify the sort order (default is 
 
 ## Specific record
 
+> Get the record with the recordid `c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8`
+
 ```http
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013(efc3e55da1dd591ba0c2bd42f0b0719e330f738f) HTTP/1.1
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000(c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8) HTTP/1.1
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013/$entity",
-    "recordid": "efc3e55da1dd591ba0c2bd42f0b0719e330f738f",
-    "gender": "M",
-    "state": "NC",
-    "number": 79,
-    "name": "Caden",
-    "year": "2013"
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000/$entity",
+    "recordid": "c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8",
+    "geonameid": "3165524",
+    "name": "Turin",
+    "asciiname": "Turin",
+    "alternatenames": "Augusta Taurinorum,Julia Augusta Taurinorum,Lungsod ng Turino,TRN,Tori,Torin,Torino,Torinu,Torí,Tueri,Turen,Turijn,Turim,Turin,Turina,Turinas,Turino,Turinu,Turyn,Turén,Turìn,Turín,Turīna,Tórínó,Türì,dou ling,tolino,torino,tu rin,tulin,turin,turina,twryn,twrynw,Τορίνο,Торино,Турин,Турын,Թուրին,טורין,טורינו,تورينو,تورین,टोरीनो,तोरिनो,তুরিন,துரின்,ตูริน,ཊུ་རིན།,ტურინი,トリノ,都灵,토리노,투린",
+    "feature_class": "P",
+    "feature_code": "PPLA",
+    "country_code": "IT",
+    "admin1_code": "12",
+    "admin2_code": "TO",
+    "admin3_code": "001272",
+    "admin4_code": "0012721",
+    "population": 870456,
+    "elevation": "239",
+    "dem": 245,
+    "timezone": "Europe/Rome",
+    "modification_date": "2019-09-05T00:00:00+00:00",
+    "geo_point_2d": {
+        "latitude": 45.07049,
+        "longitude": 7.68682
+    }
 }
 ```
 
@@ -542,29 +708,35 @@ To access a specific record, its record id surrounded by parenthesis, can be app
 
 ## Projection
 
+> Get all records that contain "Turin" in any of their fields and select only their `name`and `population` properties using projection
+
 ```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013?$search=Cad&$select=name, number
+GET https://documentation-resources.opendatasoft.com/api/odata/doc-geonames-cities-5000?$search=Turin&$select=name, population
 ```
 
 ```json
 {
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013(name,number)",
+    "@odata.context": "https://documentation-resources.opendatasoft.com/api/odata/$metadata#doc-geonames-cities-5000(name,population,recordid)",
     "value": [
         {
-            "number": 5,
-            "name": "Cadance"
+            "recordid": "c8f5d3e8e38ea441d9c4bfae5809655a58d4c2e8",
+            "name": "Turin",
+            "population": 870456
         },
         {
-            "number": 79,
-            "name": "Caden"
+            "recordid": "61eb5f69a96ba0c694a800f02802c0cc488aad91",
+            "name": "Turinskaya Sloboda",
+            "population": 6023
         },
         {
-            "number": 41,
-            "name": "Cadence"
+            "recordid": "ef5d7d2506846f5581087d9070ff90e440056e86",
+            "name": "Turinsk",
+            "population": 18555
         },
         {
-            "number": 30,
-            "name": "Cade"
+            "recordid": "e4b10f40f0dd992afc44e7cac52ede6b39f83bf5",
+            "name": "Tura",
+            "population": 5444
         }
     ]
 }
@@ -575,14 +747,3 @@ Results can be projected over specific fields using the `$select` parameter.
 For multiple fields to be subject of the projection, their names must be separated by a comma and an optional space.
 
 This parameter can be used with datasets and specific records.
-
-```text
-GET https://examples.opendatasoft.com/api/odata/baby_names_nc_2013(efc3e55da1dd591ba0c2bd42f0b0719e330f738f)?$select=name
-```
-
-```json
-{
-    "@odata.context": "https://examples.opendatasoft.com/api/odata/$metadata#baby_names_nc_2013(name)/$entity",
-    "name": "Caden"
-}
-```


### PR DESCRIPTION
## Summary

This PR updates all examples based on different domains to examples based on the `documentation-resources` domain.

Story details: https://app.clubhouse.io/opendatasoft/story/26016

## Changes

- Updated examples in the OData API docs with paths and datasets from `documentation-resources`. The UNESCO dataset could not be used anymore, [Geonames Cities with population > 5000](https://documentation-resources.opendatasoft.com/explore/dataset/doc-geonames-cities-5000/table/) is now used to show all request and response examples for consistency purposes.
- Fixed typos and grammar issues.