### PR TITLE
Updated "Literals in ODSQL clauses" section's intro

### DIFF
--- a/source/includes/v2/_odsql.md
+++ b/source/includes/v2/_odsql.md
@@ -30,7 +30,7 @@ ODSQL clauses are composed of basic language elements. These can either be liter
 
 Literals are used in comparison, assignments, or functions.
 
-There are 7 types of literal:
+There are six types of literal:
 
 - field
 - string


### PR DESCRIPTION
## Summary

This PR updates the intro of the ODSQL section from the Search API v2 docs.

Story details: https://app.clubhouse.io/opendatasoft/story/26600

## Changes

- There are only six types of literals, not seven. The intro now contains the right number.