### PR TITLE
Link to release notes in navigation header

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -113,11 +113,11 @@ under the License.
           </a>
         </div>
         <div class="ods-header__nav-item">
-        <a class="ods-header__nav-item-link"
-          href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true">
-          Release notes
-        </a>
-      </div>
+          <a class="ods-header__nav-item-link"
+            href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true">
+            Release notes
+          </a>
+        </div>
       </div>
 
     </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -112,6 +112,12 @@ under the License.
             Academy
           </a>
         </div>
+        <div class="ods-header__nav-item">
+        <a class="ods-header__nav-item-link"
+          href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true">
+          Release notes
+        </a>
+      </div>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary

This PR adds a link to the [release notes](https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true) in the navigation header, so that users can access this page when browsing the help hub.

Story details: https://app.clubhouse.io/opendatasoft/story/26719

## Changes

- New link to the release notes in the header