### PR TITLE
Add date format in where

### DIFF
--- a/source/includes/v2/_odsql.md
+++ b/source/includes/v2/_odsql.md
@@ -203,7 +203,7 @@ ss | second of minute, 00-59, left-padded with 0 | 09
 
 *Years and week years differ sligthly, see the [definition](https://en.wikipedia.org/wiki/ISO_week_date) of week years.
 
-The date format can contain free texts that won't be interpreted, they must be surrounded by a single quote `'`.
+The date format can contain a free text that won't be interpreted. Free text must be surrounded by single quotes `'`.
 To insert a single quote in the final string, it must be doubled.
 
 Some special characters can also be used as delimiters between date components: `?`, `,`, `.`, `:`, `/` and `-`.
@@ -928,7 +928,7 @@ group_by=date_format(date_field, "YYYY-MM-dd'T'HH") -- Creates a group for each 
 group_by=date_format(date_field, "w") -- Create a group for each different week in date_field
 ```
 
-Results can be grouped by parts of a date, using the `date_format` function. See the [description of the function](#date-format-function) for the full syntax.
+Results can be grouped by parts of a date, using the `date_format` function. For the full syntax, see the [description of the function](#date-format-function).
 
 ## Order by clause
 

--- a/source/includes/v2/_odsql.md
+++ b/source/includes/v2/_odsql.md
@@ -154,8 +154,8 @@ Function|Parameters|Description|Limitation
 date_format(date_field, 'dd/MM/YYYY') -- Returns '20/11/2007'
 date_format(date_field, "'The date is 'dd/MM/YYYY") -- Returns 'The date is 20/11/2007'
 date_format(date_field, "'The date is '''dd/MM/YYYY''") -- Returns "The date is '20/11/2007'"
-date_format(date_field, 'E') -- Returns the abbreviated day of week, e.g. "Tue"
-date_format(date_field, 'EEEE') -- Returns the day of week, e.g. "Tuesday"
+date_format(date_field, 'E') -- Returns 'mar.'
+date_format(date_field, 'EEEE') -- Returns 'mardi'
 date_format(date_field, 'H') -- Returns '1'
 date_format(date_field, 'HH') -- Returns '01'
 date_format(date_field, 'yy') -- Returns '07'


### PR DESCRIPTION
This PR moves the section that describes the `date_format` function, since it can now be used in all clauses (not only in group by).

So I've moved it below the "scalar functions" section.

Parameters of the function has also been cleaned up a bit.
