### PR TITLE
Replace the sort parameter with order by

### DIFF
--- a/source/includes/v2/_dataset.md
+++ b/source/includes/v2/_dataset.md
@@ -20,7 +20,7 @@ In dataset search, a field literal can either be a technical field or a field fr
 
 ```shell
 # Sort records by their technical size
-curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?sort=record_size'
+curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/doc-geonames-cities-5000/records?order_by=record_size'
 ```
 
 Field name | Description


### PR DESCRIPTION
## Summary

This PR replaces the deprecated `sort` parameter with `order_by` in an example from the API v2 docs.

Story details: https://app.clubhouse.io/opendatasoft/story/27243

## Changes

- Updated the "Sort records by their technical size" example with the `order_by` parameter.