### PR TITLE
Removed the bbox function from API v2 docs

### DIFF
--- a/source/includes/v2/_odsql.md
+++ b/source/includes/v2/_odsql.md
@@ -586,7 +586,7 @@ The distance function limits the result set to a geographical area defined by a 
 > Geometry function examples
 
 ```sql
-geometry(field_name, GEOM'<geometry>', INTERSECT)
+geometry(field_name, GEOM'<geometry>', INTERSECTS)
 geometry(field_name, GEOM'<geometry>', DISJOINT)
 geometry(field_name, GEOM'<geometry>', WITHIN)
 ```

--- a/source/includes/v2/_odsql.md
+++ b/source/includes/v2/_odsql.md
@@ -554,8 +554,7 @@ Filter functions are built-in functions that can be used in a `where` clause.
 There are 3 filter functions:
 
 - distance functions, to filter in a geographical area defined by a circle
-- geometry functions, to filter in a geographical area defined by a polygon
-- bbox functions, to filter in a rectangular box
+- geometry and polygon functions, to filter in a geographical area defined by a polygon
 
 <div class=“clearfix”></div>
 #### Distance function
@@ -620,19 +619,6 @@ Field defined by `field_name` must be of type `geo_point`.
 
 The polygon must be defined with a [geometry literal](#geometry-literal).
 
-
-<div class=“clearfix”></div>
-#### Bbox function
-
-> Bbox function example
-
-```sql
-bbox(field_name, GEOM'<geometry>', GEOM'<geometry>')
-```
-
-The bbox function limits the result set to a rectangular box.
-
-This rectangular box is defined by its top-left and its bottom-right coordinates, both expressed with 2 [geometry literals](#geometry-literal).
 
 <div class=“clearfix”></div>
 ### Comparison filter


### PR DESCRIPTION
## Summary

This PR removes the `bbox` function from the docs because it has not been implemented yet.

Story details: https://app.clubhouse.io/opendatasoft/story/27421

## Changes

- Removed the `bbox` function from the "Filter functions" subsection from the "Where clause" in the ODSQL docs.
- Slightly reworked the sentence about geometry and polygon functions to make it more explicit for users.