### PR TITLE
Added refine and exclude params to docs

### DIFF
--- a/source/includes/v2/_catalog.md
+++ b/source/includes/v2/_catalog.md
@@ -261,6 +261,8 @@ Parameter  | Default | Description
 ---------  | ------- | -----------
 `select`   | None    | Select clause for aggregation (see [select clause in ODSQL documentation](#select-clause))
 `where`    | None    | Filter expression used to restrict returned datasets (see [where clause in ODSQL documentation](#where-clause))
+`refine` | None | Refine the result set on a given facet value (see [refine in Facet documentation](#refine))
+`exclude` | None | Exclude a given facet value from the result set (see [exclude in Facet documentation](#exclude))
 `group_by` | None    | Group by clause for aggregation (see [group_by clause in ODSQL documentation](#group-by-clause))
 `order_by` | None    | Order by clause for aggregation (see [order_by clause in ODSQL documentation](#order-by-clause))
 `timezone` | UTC     | Timezone applied on datetime fields in query and response

--- a/source/includes/v2/_dataset.md
+++ b/source/includes/v2/_dataset.md
@@ -237,11 +237,12 @@ Parameter  | Default | Description
 ---------  | ------- | -----------
 `select`   | None    | Select clause for aggregation (see [select clause in ODSQL documentation](#select-clause))
 `where`    | None    | Filter expression used to restrict returned datasets (see [where clause in ODSQL documentation](#where-clause))
+`refine` | None | Refine the result set on a given facet value (see [refine in Facet documentation](#refine))
+`exclude` | None | Exclude a given facet value from the result set (see [exclude in Facet documentation](#exclude))
 `group_by` | None    | Group by clause for aggregation (see [group_by clause in ODSQL documentation](#group-by-clause))
 `order_by` | None    | Order by clause for aggregation (see [order_by clause in ODSQL documentation](#order-by-clause))
 `timezone` | UTC     | Timezone applied on datetime fields in query and response
 `limit`    | None    | Number of items to return
-
 
 ## Exporting records
 


### PR DESCRIPTION
## Summary

This PR adds the `refine` and `exclude` params to the documentation for the relevant endpoints. These params have not been added the `exports` endpoints because params are not detailed in the related sections.

Story details: https://app.clubhouse.io/opendatasoft/story/27421

## Changes

- Added the `refine` and `exclude` params where relevant.