### PR TITLE
Added iCal to the export formats available in v2

### DIFF
--- a/source/includes/v2/_dataset.md
+++ b/source/includes/v2/_dataset.md
@@ -253,7 +253,7 @@ curl 'https://documentation-resources.opendatasoft.com/api/v2/catalog/datasets/d
 
 This endpoint allows to download all records for a requested dataset.
 
-Records can be exported in 10 different formats:
+Records can be exported in different formats:
 
 - JSON
 - GeoJSON
@@ -265,6 +265,7 @@ Records can be exported in 10 different formats:
 - RDF-XML
 - N3 RDF
 - JSON-LD RDF
+- iCalendar (only if the calendar visualization has been enabled for the dataset)
 
 ##### HTTP Request
 `GET /api/v2/catalog/datasets/<dataset_id>/exports`


### PR DESCRIPTION
## Summary

This PR adds iCalendar to export formats available in the API v2 (only when the calendar visualization has been enabled for the dataset). Another PR in the user guide repo is to be open, the current PR deals with the API v2 docs only.

Story details: https://app.clubhouse.io/opendatasoft/story/28672

## Changes

- Added iCalendar to the list of export formats available in /api/v2/catalog/datasets/<dataset_id>/exports